### PR TITLE
Feature/unscheduled maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [Unreleased]
+ - Downtime-based and requests-based unscheduled maintenance models have been added to
+ servicing equipment
+
 # 0.3.1 (2021-March-2)
 
  - Updated the the `simulation/` folder to be a single-level `core/` directory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # [Unreleased]
  - Downtime-based and requests-based unscheduled maintenance models have been added to
  servicing equipment
+ - `Windfarm.current_availability` is able to account for multiple substations and is now
+ an accurate calculation of the operating level across the windfarm
 
 # 0.3.1 (2021-March-2)
 

--- a/docs/source/API/simulation.md
+++ b/docs/source/API/simulation.md
@@ -48,7 +48,8 @@ below will show how each of the APIs are powered to enable the full flexibility 
 ### Subassembly
 ```{eval-rst}
 .. automodule:: wombat.windfarm.system.subassembly
-    :members:
+   :members:
+   :undoc-members:
 ```
 
 ### Cable

--- a/wombat/core/__init__.py
+++ b/wombat/core/__init__.py
@@ -10,7 +10,10 @@ from .data_classes import (
     SubassemblyData,
     RepairRequest,
     ServiceEquipmentData,
+    ScheduledServiceEquipmentData,
+    UnscheduledServiceEquipmentData,
     FixedCosts,
+    FromDictMixin,
 )
 from .environment import WombatEnvironment
 from .post_processor import Metrics

--- a/wombat/core/environment.py
+++ b/wombat/core/environment.py
@@ -69,8 +69,8 @@ class WombatEnvironment(simpy.Environment):
             Raised if `data_dir` cannot be found.
         """
         super().__init__()
-        self.data_dir = Path(data_dir)
-        if not os.path.isdir(self.data_dir):
+        self.data_dir = Path(data_dir).resolve()
+        if not self.data_dir.is_dir():
             raise FileNotFoundError(f"{self.data_dir} does not exist")
 
         self.workday_start = workday_start

--- a/wombat/core/repair_management.py
+++ b/wombat/core/repair_management.py
@@ -175,7 +175,7 @@ class RepairManager(FilterStore):
             for equipment in equipment_mapping:
                 if operating_capacity > equipment.strategy_threshold:
                     continue
-                if equipment.equipment.onsite:
+                if equipment.equipment.onsite or equipment.equipment.enroute:
                     continue
                 self.env.process(equipment.equipment.run_unscheduled())
                 break
@@ -192,7 +192,7 @@ class RepairManager(FilterStore):
                     continue
                 # Run only the first piece of equipment in the mapping list, but ensure
                 # that it moves to the back of the line after being used
-                if equipment.equipment.onsite:
+                if equipment.equipment.onsite or equipment.equipment.enroute:
                     equipment_mapping.append(equipment_mapping.pop(i))
                     break
                 self.env.process(equipment.equipment.run_unscheduled())

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -95,9 +95,17 @@ class ServiceEquipment:
             data["start_year"] = self.env.start_year
         if data["end_year"] > self.env.end_year:
             data["end_year"] = self.env.end_year
-        self.settings = ServiceEquipmentData(**data)
+        self.settings = ServiceEquipmentData.from_dict(data)
 
-        self.env.process(self.run())
+        # Register servicing equipment with the repair manager if it is using an
+        # unscheduled maintenance scenario, so it can be dispatched as needed
+        if self.settings.strategy == "unscheduled":
+            self.manager._register_equipment(self)
+
+        # Only run the equipment if it is on a scheduled basis, otherwise wait
+        # for it to be dispatched
+        if self.settings.strategy == "scheduled":
+            self.env.process(self.run_scheduled())
 
     def _check_working_hours(self) -> None:
         """Checks the working hours of the equipment and overrides a default (-1) to
@@ -238,11 +246,19 @@ class ServiceEquipment:
         )
         yield self.env.timeout(delay)
 
-    def wait_until_next_operational_period(self) -> Generator[Timeout, None, None]:
+    def wait_until_next_operational_period(
+        self, *, less_mobilization_hours: int = 0
+    ) -> Generator[Timeout, None, None]:
         """Delays the crew and equipment until the start of the next operational
         period.
 
         TODO: Need a custom error if weather doesn't align with the equipment dates.
+
+        Parameters
+        ----------
+        less_mobilization_hours : int
+            The number of hours required for mobilization that will be subtracted from
+            the waiting period to account for mobilization, by default 0.
 
         Yields
         -------
@@ -259,6 +275,7 @@ class ServiceEquipment:
                 self.env.date_ix(next_operating_date)
                 - self.env.now
                 + self.env.workday_start
+                - less_mobilization_hours
             )
         else:
             still_in_operation = False
@@ -280,7 +297,7 @@ class ServiceEquipment:
             action="delay",
             reason="work is complete",
             additional=additional,
-            duration=0,
+            duration=hours_to_next_shift,
             salary_labor_cost=0,
             hourly_labor_cost=0,
             equipment_cost=0,
@@ -288,9 +305,9 @@ class ServiceEquipment:
 
         yield self.env.timeout(hours_to_next_shift)
 
-    def mobilize(self) -> Generator[Timeout, None, None]:
-        """Mobilizes the Equipment object by waiting for the next operational period,
-        then logging the mobiliztion cost.
+    def mobilize_scheduled(self) -> Generator[Timeout, None, None]:
+        """Mobilizes the ServiceEquipment object by waiting for the next operational
+        period, less the mobilization time, then logging the mobiliztion cost.
 
         Yields
         -------
@@ -298,8 +315,14 @@ class ServiceEquipment:
             A Timeout event for the number of hours between when the function is called
             and when the next operational period starts.
         """
-        yield self.env.process(self.wait_until_next_operational_period())
-
+        mobilization_hours = self.settings.mobilization_days * HOURS_IN_DAY
+        yield self.env.process(
+            self.wait_until_next_operational_period(
+                less_mobilization_hours=mobilization_hours
+            )
+        )
+        yield self.env.timeout(mobilization_hours)
+        self.onsite = True
         self.env.log_action(
             system_id="",
             system_name="",
@@ -311,7 +334,36 @@ class ServiceEquipment:
             action="mobilization",
             reason=f"{self.settings.name} is scheduled",
             additional="mobilization",
-            duration=0,
+            duration=mobilization_hours,
+            salary_labor_cost=0,
+            hourly_labor_cost=0,
+            equipment_cost=self.settings.mobilization_cost,
+        )
+
+    def mobilize(self) -> Generator[Timeout, None, None]:
+        """Mobilizes the ServiceEquipment object.
+
+        Yields
+        -------
+        Generator[Timeout, None, None]
+            A Timeout event for the number of hours the ServiceEquipment requires for
+            mobilizing to the windfarm site.
+        """
+        mobilization_hours = self.settings.mobilization_days * HOURS_IN_DAY
+        yield self.env.timeout(mobilization_hours)
+        self.onsite = True
+        self.env.log_action(
+            system_id="",
+            system_name="",
+            part_id="",
+            part_name="",
+            system_ol="",
+            part_ol="",
+            agent=self.settings.name,
+            action="mobilization",
+            reason=f"{self.settings.name} is scheduled",
+            additional="mobilization",
+            duration=mobilization_hours,
             salary_labor_cost=0,
             hourly_labor_cost=0,
             equipment_cost=self.settings.mobilization_cost,
@@ -344,8 +396,9 @@ class ServiceEquipment:
         satisfactory_wave = wave <= self.settings.max_waveheight_repair
         all_clear = satisfactory_wind & satisfactory_wave
 
-        delay = all_clear.size - np.count_nonzero(all_clear)
-        enough_windows = hours_required <= np.count_nonzero(all_clear)
+        total_clear_hours = np.count_nonzero(all_clear)
+        delay = all_clear.size - total_clear_hours
+        enough_windows = hours_required <= total_clear_hours
         shift_exceeded = all_clear.size > self.env.shift_length
         if enough_windows or shift_exceeded:
             return all_clear
@@ -540,7 +593,7 @@ class ServiceEquipment:
             request_id=request.request_id,
         )
 
-    def run(self) -> Generator[Process, None, None]:
+    def run_scheduled(self) -> Generator[Process, None, None]:
         """Runs the simulation.
 
         Yields
@@ -552,7 +605,7 @@ class ServiceEquipment:
             # Wait for a valid operational period to start
             if self.env.simulation_time.date() not in self.settings.operating_dates:
 
-                yield self.env.process(self.mobilize())
+                yield self.env.process(self.mobilize_scheduled())
 
             # Wait for next shift to start
             is_workshift = self.env.is_workshift(
@@ -570,6 +623,54 @@ class ServiceEquipment:
                     )
                 )
 
+            request = self.get_next_request()
+            if request is None:
+                yield self.env.process(
+                    self.wait_until_next_shift(
+                        **dict(
+                            agent=self.settings.name,
+                            reason="no requests",
+                            additional="no work requests submitted by start of shift",
+                        )
+                    )
+                )
+            else:
+                yield self.env.process(self.process_repair(request.value))
+
+    def run_unscheduled(self) -> Generator[Process, None, None]:
+        """Runs an unscheduled maintenance simulation
+
+        Yields
+        -------
+        Generator[Process, None, None]
+            The simulation
+        """
+
+        charter_end_env_time = self.settings.charter_days * HOURS_IN_DAY
+        charter_end_env_time += self.settings.mobilization_days * HOURS_IN_DAY
+        charter_end_env_time += self.env.now
+        while True:
+            if self.env.now >= charter_end_env_time:
+                break
+
+            if not self.onsite:
+                yield self.env.process(self.mobilize())
+
+            # Wait for next shift to start
+            is_workshift = self.env.is_workshift(
+                workday_start=self.settings.workday_start,
+                workday_end=self.settings.workday_end,
+            )
+            if not is_workshift:
+                yield self.env.process(
+                    self.wait_until_next_shift(
+                        **dict(
+                            agent=self.settings.name,
+                            reason="not in working hours",
+                            additional="not in working hours",
+                        )
+                    )
+                )
             request = self.get_next_request()
             if request is None:
                 yield self.env.process(

--- a/wombat/core/simulation_api.py
+++ b/wombat/core/simulation_api.py
@@ -79,7 +79,7 @@ class Configuration(FromDictMixin):
 
     name: str
     library: Path
-    layout: Union[Path, str] = attr.ib(converter=_library_mapper)
+    layout: str
     service_equipment: Union[str, List[str]]
     weather: Union[str, pd.DataFrame]
     workday_start: int
@@ -104,14 +104,14 @@ class Simulation:
     ----------
     name: str
         Name of the simulation. Used for logging files.
-    data_dir : str
+    library_path : str
         The path to the main data library.
     config : Union[str, dict]
         The path to a configuration dictionary or the dictionary itself.
     """
 
     name: str = attr.ib(converter=str)
-    data_dir: Path = attr.ib(converter=_library_mapper)
+    library_path: Path = attr.ib(converter=_library_mapper)
     config: Configuration = attr.ib()
 
     def __attrs_post_init__(self) -> None:
@@ -119,7 +119,7 @@ class Simulation:
 
     @config.validator
     def create_configuration(
-        self, attribute: str, value: Union[str, dict, Configuration]
+        self, attribute: attr.Attribute, value: Union[str, dict, Configuration]
     ) -> None:
         """Validates the configuration object and creates the `Configuration` object
         for the simulation.Raises:
@@ -136,11 +136,11 @@ class Simulation:
             The validated simulation configuration
         """
         if isinstance(value, str):
-            value = load_yaml(self.data_dir / "config", value)
+            value = load_yaml(self.library_path / "config", value)
         if isinstance(value, dict):
             value = Configuration.from_dict(value)
         if isinstance(value, Configuration):
-            object.__setattr__(self, attribute, value)
+            object.__setattr__(self, attribute.name, value)
         else:
             raise ValueError(
                 "`config` must be a dictionary, valid file path to a yaml-enocoded",

--- a/wombat/core/simulation_api.py
+++ b/wombat/core/simulation_api.py
@@ -78,7 +78,7 @@ class Configuration(FromDictMixin):
     """
 
     name: str
-    library: Path
+    library: Path = attr.ib(converter=_library_mapper)
     layout: str
     service_equipment: Union[str, List[str]]
     weather: Union[str, pd.DataFrame]
@@ -97,7 +97,7 @@ class Configuration(FromDictMixin):
 
 
 @attr.s(auto_attribs=True)
-class Simulation:
+class Simulation(FromDictMixin):
     """The primary API to interact with the simulation methodologies.
 
     Parameters

--- a/wombat/core/simulation_api.py
+++ b/wombat/core/simulation_api.py
@@ -7,12 +7,18 @@ import attr
 import pandas as pd
 from simpy.events import Event  # type: ignore
 
-from wombat.core import Metrics, RepairManager, ServiceEquipment, WombatEnvironment
+from wombat.core import (
+    FromDictMixin,
+    Metrics,
+    RepairManager,
+    ServiceEquipment,
+    WombatEnvironment,
+)
 from wombat.core.library import library_map, load_yaml
 from wombat.windfarm import Windfarm
 
 
-def _library_mapper(file_path: Union[str, Path]) -> Union[str, Path]:
+def _library_mapper(file_path: Union[str, Path]) -> Path:
     """Attempts to extract a default library path if one of "DINWOODIE" or "IEA_26"
     are passed, other returns `file_path`.
 
@@ -27,11 +33,11 @@ def _library_mapper(file_path: Union[str, Path]) -> Union[str, Path]:
     Union[str, Path]
         The library path.
     """
-    return library_map.get(file_path, file_path)
+    return Path(library_map.get(file_path, file_path)).resolve()  # type: ignore
 
 
 @attr.s(frozen=True, auto_attribs=True)
-class Configuration:
+class Configuration(FromDictMixin):
     """The `Simulation` configuration data class that provides all the necessary definitions.
 
     Parameters
@@ -73,7 +79,7 @@ class Configuration:
 
     name: str
     library: Path
-    layout: str = attr.ib(converter=_library_mapper)
+    layout: Union[Path, str] = attr.ib(converter=_library_mapper)
     service_equipment: Union[str, List[str]]
     weather: Union[str, pd.DataFrame]
     workday_start: int
@@ -90,6 +96,7 @@ class Configuration:
             object.__setattr__(self, "service_equipment", [self.service_equipment])
 
 
+@attr.s(auto_attribs=True)
 class Simulation:
     """The primary API to interact with the simulation methodologies.
 
@@ -97,38 +104,75 @@ class Simulation:
     ----------
     name: str
         Name of the simulation. Used for logging files.
-    library_path : str
+    data_dir : str
         The path to the main data library.
     config : Union[str, dict]
         The path to a configuration dictionary or the dictionary itself.
     """
 
-    def __init__(self, name: str, library_path: str, config: Union[str, dict]):
-        """Creates a `Simulation` object with an analysis ready to run.
+    name: str = attr.ib(converter=str)
+    data_dir: Path = attr.ib(converter=_library_mapper)
+    config: Configuration = attr.ib()
 
-        Parameters
-        ----------
-        name: str
-            Name of the simulation. Used for logging files.
-        library_path : str
-            The path to the main data library. If one of DINWOODIE or IEA_26
-        config : Union[str, dict]
-            The path to a configuration dictionary or the dictionary itself.
+    def __attrs_post_init__(self) -> None:
+        self.setup_simulation()
+
+    @config.validator
+    def create_configuration(
+        self, attribute: str, value: Union[str, dict, Configuration]
+    ) -> None:
+        """Validates the configuration object and creates the `Configuration` object
+        for the simulation.Raises:
+
+        Raises
+        ------
+        ValueError
+            Raised if the value provided is not able to create a valid `Configuration`
+            object
 
         Returns
         -------
-        Simulation
-            A `Simulation` object
+        Configuration
+            The validated simulation configuration
         """
-        library_path = _library_mapper(library_path)
-        self.data_dir = Path(library_path).resolve()
-        if isinstance(config, str):
-            config = load_yaml(self.data_dir / "config", config)  # type: ignore
-        config["name"] = name  # type: ignore
-        config["library"] = self.data_dir  # type: ignore
-        self.config = Configuration(**config)  # type: ignore
+        if isinstance(value, str):
+            value = load_yaml(self.data_dir / "config", value)
+        if isinstance(value, dict):
+            value = Configuration.from_dict(value)
+        if isinstance(value, Configuration):
+            object.__setattr__(self, attribute, value)
+        else:
+            raise ValueError(
+                "`config` must be a dictionary, valid file path to a yaml-enocoded",
+                "dictionary, or `Configuration` object!",
+            )
 
-        self.setup_simulation()
+    # def __init__(self, name: str, library_path: str, config: Union[str, dict]):
+    #     """Creates a `Simulation` object with an analysis ready to run.
+
+    #     Parameters
+    #     ----------
+    #     name: str
+    #         Name of the simulation. Used for logging files.
+    #     library_path : str
+    #         The path to the main data library. If one of DINWOODIE or IEA_26
+    #     config : Union[str, dict]
+    #         The path to a configuration dictionary or the dictionary itself.
+
+    #     Returns
+    #     -------
+    #     Simulation
+    #         A `Simulation` object
+    #     """
+    #     library_path = _library_mapper(library_path)
+    #     self.data_dir = Path(library_path).resolve()
+    #     if isinstance(config, str):
+    #         config = load_yaml(self.data_dir / "config", config)  # type: ignore
+    #     config["name"] = name  # type: ignore
+    #     config["library"] = self.data_dir  # type: ignore
+    #     self.config = Configuration(**config)  # type: ignore
+
+    #     self.setup_simulation()
 
     @classmethod
     def from_inputs(
@@ -206,7 +250,7 @@ class Simulation:
             project_capacity=project_capacity,
             SAM_settings=SAM_settings,
         )
-        return cls(name, library, config)
+        return cls(name, library, config)  # type: ignore
 
     def setup_simulation(self):
         """Initializes the simulation objects."""

--- a/wombat/utilities/__init__.py
+++ b/wombat/utilities/__init__.py
@@ -3,6 +3,7 @@
 
 from .utilities import (
     IEC_power_curve,
+    _mean,
     convert_dt_to_hours,
     format_events_log_message,
     hours_until_future_hour,

--- a/wombat/utilities/utilities.py
+++ b/wombat/utilities/utilities.py
@@ -9,6 +9,14 @@ import numpy as np  # type: ignore
 import pandas as pd  # type: ignore
 
 
+try:
+    from functools import cache  # type: ignore
+except ImportError:
+    from functools import lru_cache
+
+    cache = lru_cache(None)
+
+
 def convert_dt_to_hours(diff: datetime.timedelta) -> float:
     """Converts a `datetime.timedelta` object to number of hours at the seconds resolution.
 
@@ -49,6 +57,23 @@ def hours_until_future_hour(dt: datetime.datetime, hour: int) -> float:
         new_dt = dt.replace(hour=hour, minute=0, second=0)
     diff = new_dt - dt
     return convert_dt_to_hours(diff)
+
+
+@cache
+def _mean(*args) -> float:
+    """Multiplies two numbers. Used for a reduce operation.
+
+    Parameters
+    ----------
+    args : Union[int, float]
+        The values to compute the mean over
+
+    Returns
+    -------
+    float
+        The average of the values provided
+    """
+    return np.mean(args)
 
 
 def setup_logger(logger_name: str, log_file: str, level: Any = logging.INFO) -> None:
@@ -182,7 +207,7 @@ def IEC_power_curve(
     windspeed_end: float = 30.0,
 ) -> Callable:
     """
-    Direct copy, plus bug fix from OpenOA: https://github.com/NREL/OpenOA/blob/main/operational_analysis/toolkits/power_curve/functions.py#L13-L51
+    Direct copy, plus bug fix from OpenOA: https://github.com/NREL/OpenOA/blob/main/operational_analysis/toolkits/power_curve/functions.py#L16-L57
     Use IEC 61400-12-1-2 method for creating wind-speed binned power curve.
     Args:
         windspeed_column (:obj:`pandas.Series`): feature column

--- a/wombat/windfarm/system/system.py
+++ b/wombat/windfarm/system/system.py
@@ -34,8 +34,8 @@ class System:
     """Can either be a turbine or substation, but is meant to be something that consists
     of 'Subassembly' pieces.
 
-    See [here](https://www.sciencedirect.com/science/article/pii/S1364032117308985) for
-    more information.
+    See `here <https://www.sciencedirect.com/science/article/pii/S1364032117308985>`_
+    for more information.
     """
 
     def __init__(

--- a/wombat/windfarm/windfarm.py
+++ b/wombat/windfarm/windfarm.py
@@ -62,8 +62,7 @@ class Windfarm:
         windfarm_layout : str
             Filename to use for reading in the windfarm layout; must be a csv file.
         """
-        layout_path = os.path.join(self.env.data_dir, "windfarm", windfarm_layout)
-
+        layout_path = str(self.env.data_dir / "windfarm" / windfarm_layout)
         layout = (
             pd.read_csv(layout_path)
             .sort_values(by=["string", "order"])

--- a/wombat/windfarm/windfarm.py
+++ b/wombat/windfarm/windfarm.py
@@ -234,13 +234,17 @@ class Windfarm:
         """Calculates the product of all system `operating_level` variables across the
         windfarm using the following forumation
 
-        .. math:: \sum{OperatingLevel_{substation_{i}} * \sum{OperatingLevel_{turbine_{j}} * Weight_{turbine_{j}}}}  # noqa: W605
+        .. math::
+            \sum{
+                OperatingLevel_{substation_{i}} *
+                \sum{OperatingLevel_{turbine_{j}} * Weight_{turbine_{j}}}
+            }
 
-        where the \mathtt{OperatingLevel} is the product of the operating level of each  # noqa: W605
-        subassembly on a given system (substation or turbine), and the \mathtt{Weight}  # noqa: W605
-        is the proportion of one turbine's capacity relative to the whole windfarm.
-
-        """
+        where the :math:`{OperatingLevel}` is the product of the operating level
+        of each subassembly on a given system (substation or turbine), and the
+        :math:`{Weight}` is the proportion of one turbine's capacity relative to
+        the whole windfarm.
+        """  # noqa: W605
         operating_levels = {
             s_id: [
                 self.node_system(t).operating_level

--- a/wombat/windfarm/windfarm.py
+++ b/wombat/windfarm/windfarm.py
@@ -9,6 +9,7 @@ from geopy import distance  # type: ignore
 
 from wombat.core import RepairManager, WombatEnvironment
 from wombat.core.library import load_yaml
+from wombat.utilities import _mean
 from wombat.windfarm.system import Cable, System
 
 
@@ -29,6 +30,8 @@ class Windfarm:
         self._create_turbines_and_substations()
         self._create_cables()
         self.capacity = sum(self.node_system(turb).capacity for turb in self.turbine_id)
+
+        self.repair_manager._register_windfarm(self)
 
         self.env.process(self._log_operations())
 
@@ -198,3 +201,9 @@ class Windfarm:
             The `System` object.
         """
         return self.graph.nodes[system_id]["system"]
+
+    @property
+    def current_availability(self) -> float:
+        return _mean(
+            *(self.node_system(system).operating_level for system in self.graph.nodes)
+        )


### PR DESCRIPTION
Adds in a `strategy` and `strategy_threshold` for separate modeling of scheduled, downtime, and requests based servicing equipment. This allows for individual servicing equipment to operate on their own strategies, this way we can have predetermined equipment schedules for regular maintenance intervals, or wait for a specific threshold to be met before calling out equipment.

This also adds in the FromDictMixin for dataclasses, so that they can be easily compiled from dictionaries using a `cls.from_dict(the_data_dict)` classmethod.