### PR TITLE
Bug fix: interruption timing

### DIFF
--- a/wombat/core/simulation_api.py
+++ b/wombat/core/simulation_api.py
@@ -206,7 +206,8 @@ class Simulation(FromDictMixin):
 
         if self.config.library != self.library_path:
             raise ValueError(
-                "``library_path`` and the library in ``config`` do not match!"
+                f"`library_path`: {self.library_path} and the library in `config`:"
+                f" {self.config.library} do not match!"
             )
 
     @classmethod

--- a/wombat/windfarm/system/cable.py
+++ b/wombat/windfarm/system/cable.py
@@ -310,6 +310,7 @@ class Cable:
                     remainder -= self.env.now
 
             while hours_to_next > 0:
+                start = -1  # Ensure an interruption before processing is caught
                 try:
                     # If the replacement has not been completed, then wait another minute
                     yield self.servicing & self.downstream_failure & self.broken
@@ -323,8 +324,9 @@ class Cable:
                         # The subassembly had to restart the maintenance cycle
                         hours_to_next = 0
                     else:
-                        # A different interruption occurred, so subtract the elapsed time
-                        hours_to_next -= self.env.now - start  # pylint: disable=E0601
+                        # A different process failed, so subtract the elapsed time
+                        # only if it had started to be processed
+                        hours_to_next -= 0 if start == -1 else self.env.now - start
 
     def run_single_failure(self, failure: Failure) -> Generator:
         """Runs a process to trigger one type of failure repair request throughout the simulation.
@@ -350,6 +352,7 @@ class Cable:
 
             assert isinstance(hours_to_next, (int, float))  # mypy helper
             while hours_to_next > 0:  # type: ignore
+                start = -1  # Ensure an interruption before processing is caught
                 try:
                     yield self.servicing & self.downstream_failure & self.broken
 
@@ -362,5 +365,6 @@ class Cable:
                         # Restart after fixing
                         hours_to_next = 0
                     else:
-                        # A different interruption occurred, so subtract the elapsed time
-                        hours_to_next -= self.env.now - start  # pylint: disable=E0601
+                        # A different process failed, so subtract the elapsed time
+                        # only if it had started to be processed
+                        hours_to_next -= 0 if start == -1 else self.env.now - start

--- a/wombat/windfarm/system/subassembly.py
+++ b/wombat/windfarm/system/subassembly.py
@@ -179,7 +179,8 @@ class Subassembly:
                         # The subassembly had to restart the maintenance cycle
                         hours_to_next = 0
                     else:
-                        # A different subassembly failed, so subtract the elapsed time
+                        # A different process failed, so subtract the elapsed time
+                        # only if it had started to be processed
                         hours_to_next -= 0 if start == -1 else self.env.now - start
 
     def run_single_failure(self, failure: Failure) -> Generator:
@@ -218,6 +219,6 @@ class Subassembly:
                         # The subassembly had to be replaced so reset the timing
                         hours_to_next = 0
                     else:
-                        # A different subassembly failed, so subtract the elapsed time
+                        # A different process failed, so subtract the elapsed time
                         # only if it had started to be processed
                         hours_to_next -= 0 if start == -1 else self.env.now - start

--- a/wombat/windfarm/system/subassembly.py
+++ b/wombat/windfarm/system/subassembly.py
@@ -164,6 +164,7 @@ class Subassembly:
                     remainder -= self.env.now
 
             while hours_to_next > 0:
+                start = -1  # Ensure an interruption before processing is caught
                 try:
                     # Wait until these events are triggered and back to operational
                     yield self.system.servicing & self.system.cable_failure & self.broken
@@ -179,7 +180,7 @@ class Subassembly:
                         hours_to_next = 0
                     else:
                         # A different subassembly failed, so subtract the elapsed time
-                        hours_to_next -= self.env.now - start  # pylint: disable=E0601
+                        hours_to_next -= 0 if start == -1 else self.env.now - start
 
     def run_single_failure(self, failure: Failure) -> Generator:
         """Runs a process to trigger one type of failure repair request throughout the simulation.
@@ -204,6 +205,7 @@ class Subassembly:
                     remainder -= self.env.now
                 continue
             while hours_to_next > 0:  # type: ignore
+                start = -1  # Ensure an interruption before processing is caught
                 try:
                     yield self.system.servicing & self.system.cable_failure & self.broken
                     start = self.env.now
@@ -217,4 +219,5 @@ class Subassembly:
                         hours_to_next = 0
                     else:
                         # A different subassembly failed, so subtract the elapsed time
-                        hours_to_next -= self.env.now - start  # pylint: disable=E0601
+                        # only if it had started to be processed
+                        hours_to_next -= 0 if start == -1 else self.env.now - start


### PR DESCRIPTION
This PR fixes an issue with an interruption occurring before a maintenance or failure starts processing the timeout, so an UnboundLocalError is raised for the start time not yet being defined.