### PR TITLE
Bug Fix: Only Process Weather Delays Once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   - Duplicated parameters were being processed in `WombatEnvironment.log_action` stemming from improper handling of varying parameters in some of the more complex control flow logic in *in situ* repairs.
   - Another edge case of negative delays during crew transfers where there is insufficient time remaining in the shift after account for weather, so the method was called recursively, but not exiting the original loop.
   - `Port` managment of *in situ* and tow-to-port capable tugboats wasn't properly accounting for tugboas of varying capabilities, and assuming all tugboats could do both. The vessel management and repair processing were out of sync causing duplicated turbine servicing/towing.
+  - `ServiceEquipment.weather_delay()` no longer silently processes a second weather delay.
 
 ## v0.6.2 (3 February 2023)
 - Warnings from Pandas `.groupby()` calls have been silenced by shifting the column filtering to before the groupby method call.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 - Replace Flake8 and Pylint in the pre-commit workflow with ruff, and fix/ignore the resulting errors as appropriate
 - Bug fixes:
   - Maintenance and failure simulation process interruptions were occuring prior to starting the process timing, and causing simulation failures.
+  - Duplicated parameters were being processed in `WombatEnvironment.log_action` stemming from improper handling of varying parameters in some of the more complex control flow logic in *in situ* repairs.
+  - Another edge case of negative delays during crew transfers where there is insufficient time remaining in the shift after account for weather, so the method was called recursively, but not exiting the original loop.
   - `Port` managment of *in situ* and tow-to-port capable tugboats wasn't properly accounting for tugboas of varying capabilities, and assuming all tugboats could do both. The vessel management and repair processing were out of sync causing duplicated turbine servicing/towing.
 
 ## v0.6.2 (3 February 2023)

--- a/tests/test_service_equipment.py
+++ b/tests/test_service_equipment.py
@@ -1910,8 +1910,8 @@ def test_unscheduled_service_equipment_call(env_setup_full_profile):
     # The first HLV call is at 4118.374184568947 hours when S00T1's generator has a
     # catastrophic failure putting the windfarm at 83.3% operations, which is less than
     # the 90% threshold. However, because the timing will be delayed during repairs,
-    # realized timeout will be at 4166.374185 hours
-    timeout = 4163.374185
+    # realized timeout will be at 4138.374185 hours
+    timeout = 4138.374185
     env.run(timeout + 1)
     assert hlv.enroute
     assert hlv.transferring_crew is hlv.at_system is hlv.onsite is hlv.at_port is False


### PR DESCRIPTION
This PR fixes erroneous logic causing weather delays to be processed twice due to improper control flow.

Closes #80 