### PR TITLE
Bug fix: Port Stops Processing Tow-To-Port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
   - Maintenance and failure simulation process interruptions were occuring prior to starting the process timing, and causing simulation failures.
   - Duplicated parameters were being processed in `WombatEnvironment.log_action` stemming from improper handling of varying parameters in some of the more complex control flow logic in *in situ* repairs.
   - Another edge case of negative delays during crew transfers where there is insufficient time remaining in the shift after account for weather, so the method was called recursively, but not exiting the original loop.
-  - `Port` managment of *in situ* and tow-to-port capable tugboats wasn't properly accounting for tugboas of varying capabilities, and assuming all tugboats could do both. The vessel management and repair processing were out of sync causing duplicated turbine servicing/towing.
+  - `Port` managment of *in situ* and tow-to-port capable tugboats wasn't properly accounting for tugboats of varying capabilities, and assuming all tugboats could do both. The vessel management and repair processing were out of sync causing duplicated turbine servicing/towing.
+  - `RepairManager` has consolidated the dispatching of servicing equipment to be the following categories instead of the previously complex logic:
+    - If a request is a tow-to-port category, have the port initiate the process
+    - If the dispatching thresholds are met, then have the port initiate a repair for port-based servicing equipment, otherwise the repair manager will dispatch the appropriate servicing equipment.
   - `ServiceEquipment.weather_delay()` no longer silently processes a second weather delay.
 
 ## v0.6.2 (3 February 2023)

--- a/wombat/core/port.py
+++ b/wombat/core/port.py
@@ -437,8 +437,10 @@ class Port(RepairsMixin, FilterStore):
 
         self.requests_serviced.update([request.request_id])
 
-        # Request a tugboat to retrieve the tugboat
-        tugboat = yield self.ahv_tugboat_manager.get(lambda x: x.at_port)
+        # Request a vessel that isn't solely a towing vessel
+        tugboat = yield self.ahv_tugboat_manager.get(
+            lambda x: x.at_port and x.settings.capability != ["TOW"]
+        )
         assert isinstance(tugboat, ServiceEquipment)  # mypy: helper
         request = yield self.manager.get(lambda x: x == request)
         yield self.env.process(tugboat.in_situ_repair(request))

--- a/wombat/core/port.py
+++ b/wombat/core/port.py
@@ -71,7 +71,7 @@ class Port(RepairsMixin, FilterStore):
     crew_manager : simpy.Resource
         A SimPy ``Resource`` object that limts the number of repairs that can be
         occurring at any given time, which is controlled by ``settings.n_crews``.
-    tugboat_manager : simpy.FilterStore
+    service_equipment_manager : simpy.FilterStore
         A SimPy ``FilterStore`` object that acts as a coordination system for the
         registered tugboats to tow turbines between port and site. In order to tow
         in either direction they must be filtered by ``ServiceEquipment.at_port``. This
@@ -387,7 +387,7 @@ class Port(RepairsMixin, FilterStore):
 
         # Request a tugboat to retrieve the turbine
         tugboat = yield self.service_equipment_manager.get(
-            lambda x: x.at_port and "TOW" in x.capability
+            lambda x: x.at_port and "TOW" in x.settings.capability
         )
         yield self.env.process(tugboat.run_tow_to_port(request))  # type: ignore
 
@@ -402,7 +402,7 @@ class Port(RepairsMixin, FilterStore):
 
         # Request a tugboat to tow the turbine back to site, and open the turbine queue
         tugboat = yield self.service_equipment_manager.get(
-            lambda x: x.at_port and "TOW" in x.capability
+            lambda x: x.at_port and "TOW" in x.settings.capability
         )
         self.turbine_manager.release(turbine_request)
         yield self.env.process(tugboat.run_tow_to_site(request))  # type: ignore

--- a/wombat/core/repair_management.py
+++ b/wombat/core/repair_management.py
@@ -141,41 +141,46 @@ class RepairManager(FilterStore):
     def _run_equipment_downtime(self, request: RepairRequest) -> None:
         """Run any equipment that has a pending request where the current windfarm
         operating capacity is less than or equal to the servicing equipment's threshold.
+
+        TODO: This methodology needs to better resolve dispatching every equipment
+        relating to a request vs just the one(s) that are required. Basically, don't
+        dispatch every available HLV, but just one plus one of every other capability
+        category that has pending requests
         """
+        # Port-based servicing equipment should be handled by the port and does not
+        # have an operating reduction threshold to meet at this time
+        if "TOW" in request.details.service_equipment:
+            self.env.process(self.port.run_tow_to_port(request))
+            return
+
         operating_capacity = self.windfarm.current_availability_wo_servicing
         for capability in self.request_map:
             equipment_mapping = getattr(self.downtime_based_equipment, capability)
             for equipment in equipment_mapping:
                 if operating_capacity > equipment.strategy_threshold:
                     continue
-                if capability in ("TOW", "AHV"):
-                    # Don't dispatch a second piece of equipment for tow-to-port
-                    if (
-                        request.system_id in self.invalid_systems
-                        and capability == "TOW"
-                    ):
-                        continue
-                    try:
-                        self.env.process(equipment.equipment.run_unscheduled(request))
-                    except ValueError:
-                        # ValueError is raised when a duplicate request is called for
-                        # any of the port-based servicing equipment
-                        pass
-                if equipment.equipment.dispatched:
+
+                equipment_obj = equipment.equipment
+                if equipment_obj.dispatched:
                     continue
-                self.env.process(equipment.equipment.run_unscheduled(request))
+                if equipment_obj.port_based:
+                    self.env.process(self.port.run_unscheduled_in_situ(request))
+                else:
+                    self.env.process(equipment_obj.run_unscheduled(request))
 
     def _run_equipment_requests(self, request: RepairRequest) -> None:
         """Run the first piece of equipment (if none are onsite) for each equipment
         capability category where the number of requests is greater than or equal to the
         equipment's threshold.
         """
-        # Port-based servicing equipment should be handled by the port
+        # Port-based servicing equipment should be handled by the port and does not have
+        # a requests-based threshold to meet at this time
         if "TOW" in request.details.service_equipment:
             self.env.process(self.port.run_tow_to_port(request))
             return
 
         for capability, n_requests in self.request_map.items():
+            # For a requests basis, the capability and submitted request must match
             if capability not in request.details.service_equipment:
                 continue
             equipment_mapping = getattr(self.request_based_equipment, capability)

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -218,6 +218,7 @@ class ServiceEquipment(RepairsMixin):
         self.at_system = False
         self.transferring_crew = False
         self.current_system = None  # type: str | None
+        self.port_based = False  # Changed to False if port is registered
         self.settings: ScheduledServiceEquipmentData | UnscheduledServiceEquipmentData
 
         if isinstance(equipment_data_file, (str, Path)):
@@ -287,6 +288,7 @@ class ServiceEquipment(RepairsMixin):
             The port where the tugboat is based.
         """
         self.port = port
+        self.port_based = True
         self.at_port = True
         self.settings._set_port_distance(port.settings.site_distance)  # type: ignore
 
@@ -950,7 +952,7 @@ class ServiceEquipment(RepairsMixin):
 
         # MyPy helpers
         assert isinstance(distance, (int, float))
-        assert isinstance(hours, float)
+        assert isinstance(hours, (float, int))
 
         # If the the equipment will arive after the shift is over, then it must travel
         # back to port (if needed), and wait for the next shift

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -949,8 +949,8 @@ class ServiceEquipment(RepairsMixin):
                 raise ValueError("`distance` must be provided if `hours` is provided.")
 
         # MyPy helpers
+        assert isinstance(distance, (int, float))
         assert isinstance(hours, float)
-        assert isinstance(distance, float)
 
         # If the the equipment will arive after the shift is over, then it must travel
         # back to port (if needed), and wait for the next shift
@@ -1801,9 +1801,11 @@ class ServiceEquipment(RepairsMixin):
         request : RepairRequest
             The request that trigged the repair logic.
         """
-        if "TOW" in request.details.service_equipment:
-            yield self.env.process(self.port.run_tow_to_port(request))
-        elif "AHV" in request.details.service_equipment:
-            yield self.env.process(self.port.run_unscheduled_in_situ(request))
-        else:
-            yield self.env.process(self.run_unscheduled_in_situ())
+        # if "TOW" in request.details.service_equipment:
+        #     yield self.env.process(self.port.run_tow_to_port(request))
+        # if "AHV" in request.details.service_equipment:
+        # yield self.env.process(self.port.run_unscheduled_in_situ(request))
+        # else:
+        #     yield self.env.process(self.run_unscheduled_in_situ())
+
+        yield self.env.process(self.run_unscheduled_in_situ())

--- a/wombat/core/simulation_api.py
+++ b/wombat/core/simulation_api.py
@@ -287,7 +287,7 @@ class Simulation(FromDictMixin):
             self.port = Port(
                 self.env, self.windfarm, self.repair_manager, self.config.port
             )
-            self.service_equipment.extend(self.port.tugboat_manager.items)
+            self.service_equipment.extend(self.port.service_equipment_manager.items)
 
         if self.config.project_capacity * 1000 != round(self.windfarm.capacity, 6):
             raise ValueError(


### PR DESCRIPTION
This PR fixes an issue where it ports operating tow-to-port and in situ repairs seemingly stop working by implementing the following fixes:
- consolidated the dispatching logic to port-based and manager-based dispatching, and separately calling tow-to-port repairs
- Managed the port-based dispatching of vessels to align with tow-only or other capabilities to ensure that non-tow operations don't crowd out the requests for tow-to-port and tow-to-site operations
- Ports now only have one vessel management queue, regardless of vessel type to help with the above solution