### PR TITLE
Bug Fix: Correct Intra-Site Travel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,7 @@ ENV/
 /library/code_comparison/iea26/outputs
 /library/code_comparison/dinwoodie/results
 /library/code_comparison/iea26/results
+/test/library/results
 
 # Text editors
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -156,7 +156,7 @@ ENV/
 /library/code_comparison/iea26/outputs
 /library/code_comparison/dinwoodie/results
 /library/code_comparison/iea26/results
-/test/library/results
+/tests/library/results
 
 # Text editors
 .vscode/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     stages: [commit]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: 'v0.991'  # Use the sha / tag you want to point at
+  rev: 'v1.1.1'  # Use the sha / tag you want to point at
   hooks:
   - id: mypy
     entry: mypy --install-types --non-interactive --config-file .mypy.ini
@@ -40,7 +40,7 @@ repos:
 
 
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.0.246
+  rev: v0.0.255
   hooks:
   - id: ruff
     args: [--fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
     - If a request is a tow-to-port category, have the port initiate the process
     - If the dispatching thresholds are met, then have the port initiate a repair for port-based servicing equipment, otherwise the repair manager will dispatch the appropriate servicing equipment.
   - `ServiceEquipment.weather_delay()` no longer silently processes a second weather delay.
+  - Intra-site travel is now correctly logging the distance and duration of traveling between systems at the site by moving the location setting logic out of `crew_transfer` method and being entirely maintained within, or next to, the `travel` method of `ServiceEquipment`.
 
 ## v0.6.2 (3 February 2023)
 - Warnings from Pandas `.groupby()` calls have been silenced by shifting the column filtering to before the groupby method call.

--- a/tests/test_service_equipment.py
+++ b/tests/test_service_equipment.py
@@ -1920,7 +1920,6 @@ def test_unscheduled_service_equipment_call(env_setup_full_profile):
     # Test that the HLV was successfully mobilized
     timeout += 60 * 24
     env.run(timeout)
-    print(env.now, env.simulation_time)
     assert hlv.transferring_crew is hlv.at_system is hlv.onsite is True
     assert hlv.enroute is hlv.at_port is False
     assert hlv.current_system == "S00T1"

--- a/tests/test_service_equipment.py
+++ b/tests/test_service_equipment.py
@@ -1928,5 +1928,6 @@ def test_unscheduled_service_equipment_call(env_setup_full_profile):
     timeout += 30 * 24 - 1 / 60
     env.run(timeout)
     assert hlv.onsite
-    assert hlv.transferring_crew is hlv.at_system is hlv.at_port is hlv.enroute is False
-    assert hlv.current_system is None
+    assert hlv.transferring_crew is hlv.at_port is hlv.enroute is False
+    assert hlv.at_system
+    assert hlv.current_system == "S01T6"

--- a/wombat/core/mixins.py
+++ b/wombat/core/mixins.py
@@ -164,7 +164,7 @@ class RepairsMixin:
             hourly_labor_cost=hourly_cost,
             equipment_cost=equipment_cost,
             additional=action,
-            location="port" if isinstance(self.settings, PortConfig) else "site",
+            location="port" if isinstance(self.settings, PortConfig) else "system",
             **kwargs,
         )
         yield self.env.timeout(hours)

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -1191,13 +1191,6 @@ class ServiceEquipment(RepairsMixin):
         self.transferring_crew = True
         yield self.env.timeout(hours_to_process)
         self.transferring_crew = False
-        # if to_system:
-        #     self.current_system = system.id
-        # else:
-        #     self.current_system = None
-        #     self.at_system = False
-        # self._set_location("site", system.id)
-        self.current_system = system.id
         self.env.log_action(
             action="complete transfer",
             additional="complete",

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -315,8 +315,6 @@ class ServiceEquipment(RepairsMixin):
 
         Parameters
         ----------
-        start : str
-            The starting location; one of "site", or "port"
         end : str
             The ending location; one of "site", or "port"
         set_current : str

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -1164,9 +1164,7 @@ class ServiceEquipment(RepairsMixin):
             return
 
         yield self.env.process(
-            self.weather_delay(
-                delay, location="site" if to_system else "system", **shared_logging
-            )
+            self.weather_delay(delay, location="system", **shared_logging)
         )
 
         if to_system:
@@ -1186,15 +1184,15 @@ class ServiceEquipment(RepairsMixin):
         self.transferring_crew = True
         yield self.env.timeout(hours_to_process)
         self.transferring_crew = False
-        if to_system:
-            self.current_system = system.id
-        else:
-            self.current_system = None
-            self.at_system = False
+        # if to_system:
+        #     self.current_system = system.id
+        # else:
+        #     self.current_system = None
+        #     self.at_system = False
         self.env.log_action(
             action="complete transfer",
             additional="complete",
-            location="system" if to_system else "site",
+            location="system",
             **shared_logging,
         )
 
@@ -1290,7 +1288,7 @@ class ServiceEquipment(RepairsMixin):
             salary_labor_cost=salary_cost,
             hourly_labor_cost=hourly_cost,
             equipment_cost=equipment_cost,
-            location="site",
+            location="system",
             **shared_logging,  # type: ignore
         )
 
@@ -1533,7 +1531,7 @@ class ServiceEquipment(RepairsMixin):
             materials_cost=request.details.materials,
             additional="complete",
             request_id=request.request_id,
-            location="site",
+            location="system",
         )
 
         # If this is the end of the shift, ensure that we're traveling back to port

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -992,6 +992,11 @@ class ServiceEquipment(RepairsMixin):
             location="enroute",
             **kwargs,
         )
+
+        # Unregister current_system during travel <- partial fix, still need to figure
+        # out where current_system needs to be set to None to allow things to "work"
+        self._set_location("site")
+
         yield self.env.timeout(hours)
 
         self._set_location(end, set_current)
@@ -1189,6 +1194,8 @@ class ServiceEquipment(RepairsMixin):
         # else:
         #     self.current_system = None
         #     self.at_system = False
+        # self._set_location("site", system.id)
+        self.current_system = system.id
         self.env.log_action(
             action="complete transfer",
             additional="complete",


### PR DESCRIPTION
This PR fixes a bug where `ServiceEquipment.crew_transfer()` was changing the location from a specific system to the site when a crew was transferred back to the servicing equipment causing the intra-site travel to be from `None` to a system instead of from a system to another system with regards to distance traveled.