### PR TITLE
Bug fix: Ensure subassembly and cable timeouts can't be reached for non-modeled areas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - All `assert` statements are now only called when type checking is performed
 - Most of the `# type: ignore` comments have been removed or the past errors have been resolved
+- failure and maintenance logic in the `Cable` and `Subassembly` models have been wrapped in `if`/`else` blocks to ensure previously unreachable code still can't be reached under limited conditions
 
 ## v0.7.1 (4 May 2023)
 

--- a/wombat/windfarm/system/subassembly.py
+++ b/wombat/windfarm/system/subassembly.py
@@ -171,28 +171,30 @@ class Subassembly:
                     yield self.env.timeout(remainder)
                 except simpy.Interrupt:
                     remainder -= self.env.now
+            else:
+                while hours_to_next > 0:
+                    start = -1  # Ensure an interruption before processing is caught
+                    try:
+                        # Wait until these events are triggered and back to operational
+                        yield (
+                            self.system.servicing
+                            & self.system.cable_failure
+                            & self.broken
+                        )
 
-            while hours_to_next > 0:
-                start = -1  # Ensure an interruption before processing is caught
-                try:
-                    # Wait until these events are triggered and back to operational
-                    yield (
-                        self.system.servicing & self.system.cable_failure & self.broken
-                    )
-
-                    start = self.env.now
-                    yield self.env.timeout(hours_to_next)
-                    hours_to_next = 0
-                    self.trigger_request(maintenance)
-
-                except simpy.Interrupt:
-                    if not self.broken.triggered:
-                        # The subassembly had to restart the maintenance cycle
+                        start = self.env.now
+                        yield self.env.timeout(hours_to_next)
                         hours_to_next = 0
-                    else:
-                        # A different process failed, so subtract the elapsed time
-                        # only if it had started to be processed
-                        hours_to_next -= 0 if start == -1 else self.env.now - start
+                        self.trigger_request(maintenance)
+
+                    except simpy.Interrupt:
+                        if not self.broken.triggered:
+                            # The subassembly had to restart the maintenance cycle
+                            hours_to_next = 0
+                        else:
+                            # A different process failed, so subtract the elapsed time
+                            # only if it had started to be processed
+                            hours_to_next -= 0 if start == -1 else self.env.now - start
 
     def run_single_failure(self, failure: Failure) -> Generator:
         """Runs a process to trigger one type of failure repair request throughout the
@@ -217,22 +219,25 @@ class Subassembly:
                 except simpy.Interrupt:
                     remainder -= self.env.now
                 continue
-            while hours_to_next > 0:  # type: ignore
-                start = -1  # Ensure an interruption before processing is caught
-                try:
-                    yield (
-                        self.system.servicing & self.system.cable_failure & self.broken
-                    )
-                    start = self.env.now
-                    yield self.env.timeout(hours_to_next)
-                    hours_to_next = 0
-                    self.trigger_request(failure)
-
-                except simpy.Interrupt:
-                    if not self.broken.triggered:
-                        # The subassembly had to be replaced so reset the timing
+            else:
+                while hours_to_next > 0:  # type: ignore
+                    start = -1  # Ensure an interruption before processing is caught
+                    try:
+                        yield (
+                            self.system.servicing
+                            & self.system.cable_failure
+                            & self.broken
+                        )
+                        start = self.env.now
+                        yield self.env.timeout(hours_to_next)
                         hours_to_next = 0
-                    else:
-                        # A different process failed, so subtract the elapsed time
-                        # only if it had started to be processed
-                        hours_to_next -= 0 if start == -1 else self.env.now - start
+                        self.trigger_request(failure)
+
+                    except simpy.Interrupt:
+                        if not self.broken.triggered:
+                            # The subassembly had to be replaced so reset the timing
+                            hours_to_next = 0
+                        else:
+                            # A different process failed, so subtract the elapsed time
+                            # only if it had started to be processed
+                            hours_to_next -= 0 if start == -1 else self.env.now - start


### PR DESCRIPTION
In the latest release, sometimes previously unreachable code blocks in `run_single_failure` and `run_single_maintenance` have been inappropriately reached following an interruption. By adding an `if`/`else` block in place of a single `if`, the errors can no longer be reached.