### PR TITLE
Enhancement/speedup request checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 - All `assert` statements are now only called when type checking is performed
 - Most of the `# type: ignore` comments have been removed or the past errors have been resolved
-- failure and maintenance logic in the `Cable` and `Subassembly` models have been wrapped in `if`/`else` blocks to ensure previously unreachable code still can't be reached under limited conditions
+- Failure and maintenance logic in the `Cable` and `Subassembly` models have been wrapped in `if`/`else` blocks to ensure previously unreachable code still can't be reached under limited conditions
+- Replaces all `.get(lamda x: x == request)` with a 10x faster `.get(lambda x: x is request)` to more efficiently filter out the desired event to be removed from the repair manager and port repair manangement.
 
 ## v0.7.1 (4 May 2023)
 

--- a/wombat/core/port.py
+++ b/wombat/core/port.py
@@ -199,7 +199,7 @@ class Port(RepairsMixin, FilterStore):
             The submitted repair or maintenance request.
         """
         # Retrieve the actual request
-        request = yield self.get(lambda r: r == request)  # type: ignore
+        request = yield self.get(lambda r: r is request)  # type: ignore
 
         # Request a service crew
         crew_request = self.crew_manager.request()
@@ -481,7 +481,7 @@ class Port(RepairsMixin, FilterStore):
         )
         if TYPE_CHECKING:
             assert isinstance(vessel, ServiceEquipment)  # mypy: helper
-        request = yield self.manager.get(lambda x: x == request)
+        request = yield self.manager.get(lambda x: x is request)
         yield self.env.process(vessel.in_situ_repair(request))
 
         # If the tugboat finished mid-shift, the in-situ repair logic will keep it

--- a/wombat/core/repair_management.py
+++ b/wombat/core/repair_management.py
@@ -198,13 +198,13 @@ class RepairManager(FilterStore):
                         break
 
                     # Dispatch-triggering request must be removed from the queue
-                    _ = self.get(lambda x: x == request)
+                    _ = self.get(lambda x: x is request)
 
                     yield self.windfarm.system(request.system_id).servicing
                     self.env.process(self.port.run_unscheduled_in_situ(request))
                 else:
                     # Dispatch-triggering request must be removed from the queue
-                    _ = self.get(lambda x: x == request)
+                    _ = self.get(lambda x: x is request)
 
                     yield self.in_process_requests.put(request)
                     self.env.process(equipment_obj.run_unscheduled_in_situ(request))
@@ -267,12 +267,12 @@ class RepairManager(FilterStore):
                         break
 
                     # Dispatch-triggering request must be removed from the queue
-                    _ = self.get(lambda x: x == request)
+                    _ = self.get(lambda x: x is request)
 
                     yield self.env.process(self.port.run_unscheduled_in_situ(request))
                 else:
                     # Dispatch-triggering request must be removed from the queue
-                    _ = self.get(lambda x: x == request)
+                    _ = self.get(lambda x: x is request)
 
                     yield self.in_process_requests.put(request)
                     yield self.env.process(
@@ -397,7 +397,7 @@ class RepairManager(FilterStore):
                 # servicing equipment can access it
                 if request.system_id not in self.invalid_systems:
                     self.invalid_systems.append(request.system_id)
-                return self.get(lambda x: x == requests[0])
+                return self.get(lambda x: x is requests[0])
 
         # There were no matching equipment requirements to match the equipment
         # attempting to retrieve its next request
@@ -450,7 +450,7 @@ class RepairManager(FilterStore):
             if request.system_id not in self.invalid_systems:
                 if equipment_capability.intersection(request.details.service_equipment):
                     self.invalid_systems.append(request.system_id)
-                    return self.get(lambda x: x == request)
+                    return self.get(lambda x: x is request)
 
         # Ensure None is returned if nothing is found in the loop just as a FilterGet
         # would if allowed to oeprate without the above looping to identify multiple
@@ -496,7 +496,7 @@ class RepairManager(FilterStore):
         if port:
             yield self.completed_requests.put(repair)
         else:
-            request = yield self.in_process_requests.get(lambda x: x == repair)
+            request = yield self.in_process_requests.get(lambda x: x is repair)
             yield self.completed_requests.put(request)
 
     def enable_requests_for_system(self, system: System | Cable) -> None:
@@ -559,7 +559,7 @@ class RepairManager(FilterStore):
                 reason="",
                 request_id=request.request_id,
             )
-            _ = self.get(lambda x: x == request)  # pylint: disable=W0640
+            _ = self.get(lambda x: x is request)  # pylint: disable=W0640
 
         return requests
 
@@ -616,7 +616,7 @@ class RepairManager(FilterStore):
                 reason="replacement required",
                 request_id=request.request_id,
             )
-            _ = self.get(lambda x: x == request)  # pylint: disable=W0640
+            _ = self.get(lambda x: x is request)  # pylint: disable=W0640
         return requests
 
     @property


### PR DESCRIPTION
This PR addresses the slowness in request filtering by matching a `RepairRequest` through an `x is request` in place of `x == request` to more efficiently filter out the pre-determined request match.