### PR TITLE
Bug fix/24 hour shift timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Most of the `# type: ignore` comments have been removed or the past errors have been resolved
 - Failure and maintenance logic in the `Cable` and `Subassembly` models have been wrapped in `if`/`else` blocks to ensure previously unreachable code still can't be reached under limited conditions
 - Replaces all `.get(lamda x: x == request)` with a 10x faster `.get(lambda x: x is request)` to more efficiently filter out the desired event to be removed from the repair manager and port repair manangement.
+- Adds a `non_stop_shift` attribute to `ServiceEquipmentData`, `UnscheduledServiceEquipmentData`, `ScheduledServiceEquipmentData`, and `PortConfig` that is set in the post-initialization hook or through `DateLimitsMixin._set_environment_shift()` to ensure it is updated appropriately. Additionally, all checks for a 24 hour shift now check for the `non_stop_shift` attribute.
 
 ## v0.7.1 (4 May 2023)
 

--- a/tests/test_service_equipment.py
+++ b/tests/test_service_equipment.py
@@ -2020,4 +2020,4 @@ def test_unscheduled_service_equipment_call(env_setup_full_profile):
     assert hlv.onsite is hlv.at_site is True
     assert hlv.transferring_crew is hlv.at_port is hlv.enroute is False
     assert hlv.at_system
-    assert hlv.current_system == "S01T6"
+    assert hlv.current_system == "S01T4"

--- a/wombat/core/data_classes.py
+++ b/wombat/core/data_classes.py
@@ -734,6 +734,8 @@ class DateLimitsMixin:
         """
         object.__setattr__(self, "workday_start", start)
         object.__setattr__(self, "workday_end", end)
+        if self.workday_start == 0 and self.workday_end == 24:  # type: ignore
+            object.__setattr__(self, "non_stop_shift", True)
 
     def _set_port_distance(self, distance: int | float | None) -> None:
         """Set ``port_distance`` from the environment's or port's variables.

--- a/wombat/core/data_classes.py
+++ b/wombat/core/data_classes.py
@@ -1115,6 +1115,7 @@ class ScheduledServiceEquipmentData(FromDictMixin, DateLimitsMixin):
     non_operational_dates: pd.DatetimeIndex = field(factory=list, init=False)
     non_operational_dates_set: pd.DatetimeIndex = field(factory=set, init=False)
     reduced_speed_dates: pd.DatetimeIndex = field(factory=set, init=False)
+    non_stop_shift: bool = field(default=False, init=False)
 
     def create_date_range(self) -> np.ndarray:
         """Create an ``np.ndarray`` of valid operational dates."""
@@ -1143,6 +1144,8 @@ class ScheduledServiceEquipmentData(FromDictMixin, DateLimitsMixin):
         """Post-initialization."""
         object.__setattr__(self, "operating_dates", self.create_date_range())
         object.__setattr__(self, "operating_dates_set", set(self.operating_dates))
+        if self.workday_start == 0 and self.workday_end == 24:
+            object.__setattr__(self, "non_stop_shift", True)
 
 
 @define(frozen=True, auto_attribs=True)
@@ -1320,6 +1323,7 @@ class UnscheduledServiceEquipmentData(FromDictMixin, DateLimitsMixin):
     non_operational_dates: pd.DatetimeIndex = field(factory=list, init=False)
     non_operational_dates_set: pd.DatetimeIndex = field(factory=set, init=False)
     reduced_speed_dates: pd.DatetimeIndex = field(factory=set, init=False)
+    non_stop_shift: bool = field(default=False, init=False)
 
     @strategy_threshold.validator  # type: ignore
     def _validate_threshold(
@@ -1340,6 +1344,11 @@ class UnscheduledServiceEquipmentData(FromDictMixin, DateLimitsMixin):
                     "Requests-based strategies must have a ``strategy_threshold``",
                     "greater than 0!",
                 )
+
+    def __attrs_post_init__(self) -> None:
+        """Post-initialization hook."""
+        if self.workday_start == 0 and self.workday_end == 24:
+            object.__setattr__(self, "non_stop_shift", True)
 
 
 @define(frozen=True, auto_attribs=True)
@@ -1674,6 +1683,12 @@ class PortConfig(FromDictMixin, DateLimitsMixin):
     reduced_speed_dates: pd.DatetimeIndex = field(factory=set, init=False)
     non_operational_dates_set: pd.DatetimeIndex = field(factory=set, init=False)
     reduced_speed_dates_set: pd.DatetimeIndex = field(factory=set, init=False)
+    non_stop_shift: bool = field(default=False, init=False)
+
+    def __attrs_post_init__(self) -> None:
+        """Post-initialization hook."""
+        if self.workday_start == 0 and self.workday_end == 24:
+            object.__setattr__(self, "non_stop_shift", True)
 
 
 @define(frozen=True, auto_attribs=True)

--- a/wombat/core/mixins.py
+++ b/wombat/core/mixins.py
@@ -102,6 +102,10 @@ class RepairsMixin:
             A boolean array for which values in working hours (True), and which values
             are outside working hours (False).
         """
+        if self.settings.non_stop_shift:
+            if isinstance(hour_ix, np.ndarray):
+                return np.ones(hour_ix.shape)
+            return True
         is_workshift = self.settings.workday_start <= hour_ix
         is_workshift &= hour_ix <= self.settings.workday_end
         return is_workshift

--- a/wombat/core/mixins.py
+++ b/wombat/core/mixins.py
@@ -104,7 +104,7 @@ class RepairsMixin:
         """
         if self.settings.non_stop_shift:
             if isinstance(hour_ix, np.ndarray):
-                return np.ones(hour_ix.shape)
+                return np.ones(hour_ix.shape, dtype=bool)
             return True
         is_workshift = self.settings.workday_start <= hour_ix
         is_workshift &= hour_ix <= self.settings.workday_end

--- a/wombat/core/mixins.py
+++ b/wombat/core/mixins.py
@@ -102,13 +102,14 @@ class RepairsMixin:
             A boolean array for which values in working hours (True), and which values
             are outside working hours (False).
         """
-        if self.settings.non_stop_shift:
-            if isinstance(hour_ix, np.ndarray):
-                return np.ones(hour_ix.shape, dtype=bool)
-            return True
-        is_workshift = self.settings.workday_start <= hour_ix
-        is_workshift &= hour_ix <= self.settings.workday_end
-        return is_workshift
+        if not self.settings.non_stop_shift:
+            is_workshift = self.settings.workday_start <= hour_ix
+            is_workshift &= hour_ix <= self.settings.workday_end
+            return is_workshift
+
+        if isinstance(hour_ix, np.ndarray):
+            return np.ones(hour_ix.shape, dtype=bool)
+        return True
 
     def wait_until_next_shift(self, **kwargs) -> Generator[Timeout, None, None]:
         """Delays the process until the start of the next shift.

--- a/wombat/core/port.py
+++ b/wombat/core/port.py
@@ -206,10 +206,7 @@ class Port(RepairsMixin, FilterStore):
         yield crew_request
 
         # Once a crew is available, process the acutal repair
-        # Get the shift parameters
-        start_shift = self.settings.workday_start
         end_shift = self.settings.workday_end
-        continuous_operations = start_shift == 0 and end_shift == 24
 
         # Set the default hours to process and remaining hours for the repair
         hours_to_process = hours_remaining = request.details.time
@@ -233,7 +230,7 @@ class Port(RepairsMixin, FilterStore):
             current = self.env.simulation_time
 
             # Check if the workday is limited by shifts and adjust to stay within shift
-            if not continuous_operations:
+            if not self.settings.non_stop_shift:
                 hours_to_process = hours_until_future_hour(current, end_shift)
 
             # Delay until the next shift if we're at the end


### PR DESCRIPTION
This PR fixes an issue where servicing equipment are waiting for the next shift despite having a start and end time of 0  and 24, respectively, to indicate a continuous shift. See the changelog for details.