### PR TITLE
Bug Fix: Repair duplication and multiple completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixes a bug in where the mobilization duration is logged. Previously, the mobilization duration was logged upon completion, but now is logged while during the actual mobilizing, with costs still being logged upon completion.
 - Fixes an uncommon error where repairs are made twice causing the simulation to fail. This was caused by a control mismatch in the unscheduled repair process, and was fixed by better tracking and controlling when a repair moves from "pending" (submitted), to "processing" (handed off to the servicing equipment for repair or to the port for a tow-to-port repair cycle), to "completed" (the repair is registered as complete). Additionally, the servicing equipment no longer relies on receiving the first repair from the repair manager on dispatch, and follows the same `get_next_request()` logic that will occur following the initial dispatch and repair.
 - Fixes an error where a repair has `replacement=True` and `operation_reduction` < 1 both resets the `operating_level` back to 1 and readjusts for the `operation_reduction`, which can cause `operating_level` > 100%
+- `ServiceEquipment.crew_transfer()` uses a while loop in place of an `if` with recursion strategy to handle unsafe transfer conditions to continuously wait until the next shift's available window.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,23 @@
 ## Unreleased (TBD)
 
-- All `assert` statements are now only called when type checking is performed
+### Bug Fixes
+
 - Most of the `# type: ignore` comments have been removed or the past errors have been resolved
 - Failure and maintenance logic in the `Cable` and `Subassembly` models have been wrapped in `if`/`else` blocks to ensure previously unreachable code still can't be reached under limited conditions
-- Replaces all `.get(lamda x: x == request)` with a 10x faster `.get(lambda x: x is request)` to more efficiently filter out the desired event to be removed from the repair manager and port repair manangement.
-- Adds a `non_stop_shift` attribute to `ServiceEquipmentData`, `UnscheduledServiceEquipmentData`, `ScheduledServiceEquipmentData`, and `PortConfig` that is set in the post-initialization hook or through `DateLimitsMixin._set_environment_shift()` to ensure it is updated appropriately. Additionally, all checks for a 24 hour shift now check for the `non_stop_shift` attribute.
-- `WombatEnvironment.weather` is now a Polars DataFrame to improve efficiency and indexing bottlenecks introduced in Pandas 2.0.
 - Fixes a bug in where the mobilization duration is logged. Previously, the mobilization duration was logged upon completion, but now is logged while during the actual mobilizing, with costs still being logged upon completion.
+- Fixes an uncommon error where repairs are made twice causing the simulation to fail. This was caused by a control mismatch in the unscheduled repair process, and was fixed by better tracking and controlling when a repair moves from "pending" (submitted), to "processing" (handed off to the servicing equipment for repair or to the port for a tow-to-port repair cycle), to "completed" (the repair is registered as complete). Additionally, the servicing equipment no longer relies on receiving the first repair from the repair manager on dispatch, and follows the same `get_next_request()` logic that will occur following the initial dispatch and repair.
+- Fixes an error where a repair has `replacement=True` and `operation_reduction` < 1 both resets the `operating_level` back to 1 and readjusts for the `operation_reduction`, which can cause `operating_level` > 100%
+
+### Features
+
+- Adds a `non_stop_shift` attribute to `ServiceEquipmentData`, `UnscheduledServiceEquipmentData`, `ScheduledServiceEquipmentData`, and `PortConfig` that is set in the post-initialization hook or through `DateLimitsMixin._set_environment_shift()` to ensure it is updated appropriately. Additionally, all checks for a 24 hour shift now check for the `non_stop_shift` attribute.
 - `Metrics.emissions()` has been added to the list of available metrics to calculate the emissions from idling at port or sea, tranisiting, and maneuvering. Co-authored by and inspired by analysis work from @hemezz.
+
+### General
+
+- All `assert` statements are now only called when type checking is performed
+- Replaces all `.get(lamda x: x == request)` with a 10x faster `.get(lambda x: x is request)` to more efficiently filter out the desired event to be removed from the repair manager and port repair manangement.
+- `WombatEnvironment.weather` is now a Polars DataFrame to improve efficiency and indexing bottlenecks introduced in Pandas 2.0.
 
 ## v0.7.1 (4 May 2023)
 

--- a/tests/test_service_equipment.py
+++ b/tests/test_service_equipment.py
@@ -1973,7 +1973,7 @@ def test_unscheduled_service_equipment_call(env_setup_full_profile):
     env.run(timeout)
     assert fsv.onsite is fsv.at_site is fsv.transferring_crew is fsv.at_system is True
     assert fsv.at_port is fsv.enroute is False
-    assert fsv.current_system == "S00T3"
+    assert fsv.current_system == "S00T1"
 
     # The FSV should no longer be on site after 28 days, plus the time to finish the
     # repair that it's started
@@ -1993,8 +1993,8 @@ def test_unscheduled_service_equipment_call(env_setup_full_profile):
     # The first HLV call is at 4118.374184568947 hours when S00T1's generator has a
     # catastrophic failure putting the windfarm at 83.3% operations, which is less than
     # the 90% threshold. However, because the timing will be delayed during repairs,
-    # realized timeout will be at 4154.386685 hours
-    timeout = 4154.386685
+    # realized timeout will be at 4653.37 hours
+    timeout = 4653.37
     env.run(timeout + 1)
     assert hlv.enroute
     assert (
@@ -2020,4 +2020,4 @@ def test_unscheduled_service_equipment_call(env_setup_full_profile):
     assert hlv.onsite is hlv.at_site is True
     assert hlv.transferring_crew is hlv.at_port is hlv.enroute is False
     assert hlv.at_system
-    assert hlv.current_system == "S01T4"
+    assert hlv.current_system == "S01T5"

--- a/wombat/core/data_classes.py
+++ b/wombat/core/data_classes.py
@@ -686,6 +686,10 @@ class RepairRequest(FromDictMixin):
         object.__setattr__(self, "request_id", request_id)
         self.details.assign_id(request_id)
 
+    def __eq__(self, other) -> bool:
+        """Redefines the equality method to only check for the ``request_id``."""
+        return self.request_id == other.request_id
+
 
 @define(frozen=True, auto_attribs=True)
 class ServiceCrew(FromDictMixin):

--- a/wombat/core/repair_management.py
+++ b/wombat/core/repair_management.py
@@ -422,7 +422,7 @@ class RepairManager(FilterStore):
                     [requests[0].request_id]
                 )
                 self.request_status_map["processing"].update([requests[0].request_id])
-                yield self.get(lambda x: x is requests[0])
+                return self.get(lambda x: x is requests[0])
 
         # There were no matching equipment requirements to match the equipment
         # attempting to retrieve its next request

--- a/wombat/core/repair_management.py
+++ b/wombat/core/repair_management.py
@@ -418,6 +418,8 @@ class RepairManager(FilterStore):
         if TYPE_CHECKING:
             assert isinstance(equipment_capability, set)
         for request in requests:
+            if self.in_process_requests(request):
+                continue
             if equipment_capability.intersection(request.details.service_equipment):
                 # If this is the first request for the system, make sure no other
                 # servicing equipment can access it
@@ -467,6 +469,8 @@ class RepairManager(FilterStore):
         # back
         requests = sorted(requests, key=lambda x: x.severity_level, reverse=True)
         for request in requests:
+            if self.in_process_requests(request):
+                continue
             if request.cable:
                 if not self.windfarm.cable(request.system_id).servicing.triggered:
                     continue

--- a/wombat/core/repair_management.py
+++ b/wombat/core/repair_management.py
@@ -422,7 +422,7 @@ class RepairManager(FilterStore):
                     [requests[0].request_id]
                 )
                 self.request_status_map["processing"].update([requests[0].request_id])
-                return self.get(lambda x: x is requests[0])
+                yield self.get(lambda x: x is requests[0])
 
         # There were no matching equipment requirements to match the equipment
         # attempting to retrieve its next request

--- a/wombat/core/repair_management.py
+++ b/wombat/core/repair_management.py
@@ -418,7 +418,7 @@ class RepairManager(FilterStore):
         if TYPE_CHECKING:
             assert isinstance(equipment_capability, set)
         for request in requests:
-            if self.in_process_requests(request):
+            if self._is_request_processing(request):
                 continue
             if equipment_capability.intersection(request.details.service_equipment):
                 # If this is the first request for the system, make sure no other
@@ -469,7 +469,7 @@ class RepairManager(FilterStore):
         # back
         requests = sorted(requests, key=lambda x: x.severity_level, reverse=True)
         for request in requests:
-            if self.in_process_requests(request):
+            if self._is_request_processing(request):
                 continue
             if request.cable:
                 if not self.windfarm.cable(request.system_id).servicing.triggered:

--- a/wombat/core/repair_management.py
+++ b/wombat/core/repair_management.py
@@ -526,7 +526,7 @@ class RepairManager(FilterStore):
         """
         if port:
             self.request_status_map["processing"].difference_update([repair.request_id])
-            self.requesrequest_status_mapt_map["completed"].update([repair.request_id])
+            self.request_status_map["completed"].update([repair.request_id])
             yield self.completed_requests.put(repair)
         else:
             self.request_status_map["processing"].difference_update([repair.request_id])

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -900,7 +900,7 @@ class ServiceEquipment(RepairsMixin):
             # return the max amount of time, but if that's not the case re-raise the
             # error.
             if self.env.end_datetime in dt:
-                ix_hours = distance_traveled.size - 1
+                ix_hours = distance_traveled.shape[0] - 1
             else:
                 raise e
 

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -1159,7 +1159,7 @@ class ServiceEquipment(RepairsMixin):
 
         delay, shift_delay = self.find_uninterrupted_weather_window(hours_to_process)
         # If there is a shift delay, then travel to port, wait, and travel back, and
-        # finally try again.
+        # try again, until no shift delay is required.
         while shift_delay:
             travel_time = self.env.now
             yield self.env.process(

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -484,7 +484,7 @@ class ServiceEquipment(RepairsMixin):
             _ = self.manager.purge_subassembly_requests(
                 repair.system_id, repair.subassembly_id
             )
-        if operation_reduction == 1:
+        elif operation_reduction == 1:
             subassembly.operating_level = starting_operating_level
             subassembly.broken.succeed()
         elif operation_reduction == 0:
@@ -1185,6 +1185,7 @@ class ServiceEquipment(RepairsMixin):
                     start="port", end="site", set_current=system.id, **shared_logging
                 )
             )
+            # TODO: SEE IF THE BELOW NEEDS TO BE DROPPED!
             yield self.env.process(
                 self.crew_transfer(system, subassembly, request, to_system=to_system)
             )

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -1160,7 +1160,7 @@ class ServiceEquipment(RepairsMixin):
         delay, shift_delay = self.find_uninterrupted_weather_window(hours_to_process)
         # If there is a shift delay, then travel to port, wait, and travel back, and
         # finally try again.
-        if shift_delay:
+        while shift_delay:
             travel_time = self.env.now
             yield self.env.process(
                 self.travel(start="site", end="port", **shared_logging)
@@ -1185,11 +1185,9 @@ class ServiceEquipment(RepairsMixin):
                     start="port", end="site", set_current=system.id, **shared_logging
                 )
             )
-            # TODO: SEE IF THE BELOW NEEDS TO BE DROPPED!
-            yield self.env.process(
-                self.crew_transfer(system, subassembly, request, to_system=to_system)
+            delay, shift_delay = self.find_uninterrupted_weather_window(
+                hours_to_process
             )
-            return
 
         yield self.env.process(
             self.weather_delay(delay, location="system", **shared_logging)


### PR DESCRIPTION
This PR addresses three inter-related issues:
1. Operating levels > 100% due to the subassembly reset process' improper use of multiple if statements in place of a longer if/elif block
2. Repairs being completed more than once due to an improper recursive loop in the crew transfer mechanisms during shift delays
3. Repairs having equipment dispatched more than once due to inconsistent handling of pending, processing, and completed repair statuses

See the changelog for complete details.