### PR TITLE
Update Test PyPI action settings

### DIFF
--- a/.github/workflows/python-publish-test.yml
+++ b/.github/workflows/python-publish-test.yml
@@ -35,4 +35,4 @@ jobs:
         with:
           verbose: True
           password: ${{ secrets.TEST_PYPI_PASSWORD }}
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
This PR silences a GH Action warning stemming from  a change in configuration key naming conventions.