### PR TITLE
Bug Fix: Improper use of `cls`

### DIFF
--- a/wombat/core/simulation_api.py
+++ b/wombat/core/simulation_api.py
@@ -279,8 +279,8 @@ class Simulation(FromDictMixin):
         return cls(  # type: ignore
             library_path=config.library,
             config=config,
-            random_seed=cls.random_seed,
-            random_generator=cls.random_generator,
+            random_seed=config.random_seed,
+            random_generator=config.random_generator,
         )
 
     def _setup_simulation(self):


### PR DESCRIPTION
This PR fixes an issue where `Simulation.from_config()` generates the `cls` object while referencing `cls` properties improperly, instead of `config`.