### PR TITLE
Bug Fix: Ensure system downtime starts appropriately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Subassemblies and cables are now able to resample their next times to failure for all maintenance and failure activities, so that replacement events reset the timing for failures across the board.
 - Systems are no longer interrupted once the servicing equipment addressing a repair or maintenance task is dispatched, and instead are interrupted just before the crew is transferred to begin repair, maintenance, or unmorring. This has a small net positive increase in the availability for short travel distances, but can vary if the travel time is more than a few hours (i.e., large distance to port, slow travel due to weather, & etc.)
+- When a tow to port repair is in the queue, no other repairs or maintenance activities will occur for that turbine until it's brought into port for repairs.
 
 ## v0.8.1 (28 August 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
 ## Unreleased
 
+### Bug Fixes
+
+- Repairs that had a weather delay extended repairs past the end of the shift now properly extend the repair into future shifts instead of completing early. This has a small negative impact on availability because that means some repairs can take longer than they had originally.
+- Traveling to a system for a repair where the timing extends beyond the end of the shift, but into the next shift, is now registered as a shift delay just like travel weather delays that extend beyond the end of the current shift but before the start of the next shift. This has a small positive impact on availability because a turbine or cable may not start being repaired until weather is more consistently clear, rather than starting it and extending it for many shifts.
+
+### General Updates
+
 - `Metrics.equipment_labor_cost_breakdowns` now has a `by_equipment` boolean flag, so that the labor and equipment costs can be broken down by category and equipment. Additionally, `total_hours` has been added to the results, resulting in fewer computed metrics across the same set of breakdowns.
+
+### Methodology Updates
+
 - Subassemblies and cables are now able to resample their next times to failure for all maintenance and failure activities, so that replacement events reset the timing for failures across the board.
+- Systems are no longer interrupted once the servicing equipment addressing a repair or maintenance task is dispatched, and instead are interrupted just before the crew is transferred to begin repair, maintenance, or unmorring. This has a small net positive increase in the availability for short travel distances, but can vary if the travel time is more than a few hours (i.e., large distance to port, slow travel due to weather, & etc.)
 
 ## v0.8.1 (28 August 2023)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,13 @@ omit = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--strict --pdbcls=tests:Debugger -r sxX --cov=wombat --cov-report=html --cov-report=term-missing:skip-covered --no-cov-on-fail --ignore=setup.py"
+addopts = "--strict-markers --pdbcls=tests:Debugger -r sxX --cov=wombat --cov-report=html --cov-report=term-missing:skip-covered --no-cov-on-fail --ignore=setup.py"
 testpaths = "tests"
 cache_dir = ".cache"
+filterwarnings = [
+  "ignore::DeprecationWarning:simpy.*:",
+  "ignore::DeprecationWarning:pkg_resources.*:",
+]
 
 [tool.isort]
 skip = [

--- a/tests/test_repair_manager.py
+++ b/tests/test_repair_manager.py
@@ -153,7 +153,6 @@ def test_register_request_and_submit_request_and_get_request(env_setup):
     assert retrieved_request.value == repair_request_failure
 
     retrieved_request = manager.get_request_by_system(["CTV"], system_id=turbine.id)
-    print(retrieved_request.value)
     assert retrieved_request.value is repair_request_maintenance
 
     assert manager.items == []

--- a/tests/test_repair_manager.py
+++ b/tests/test_repair_manager.py
@@ -152,13 +152,11 @@ def test_register_request_and_submit_request_and_get_request(env_setup):
     retrieved_request = manager.get_request_by_system(["CTV"], system_id=turbine.id)
     assert retrieved_request.value == repair_request_failure
 
-    # Ensure that the turbine has been labeled invalid so that another servicing
-    # equipment can't access it
-    assert manager.invalid_systems == [turbine.id]
     retrieved_request = manager.get_request_by_system(["CTV"], system_id=turbine.id)
-    assert retrieved_request is None
+    print(retrieved_request.value)
+    assert retrieved_request.value is repair_request_maintenance
 
-    assert manager.items == [repair_request_maintenance]
+    assert manager.items == []
 
 
 def test_request_map(env_setup):
@@ -308,7 +306,8 @@ def test_get_requests(env_setup):
 
     # Test that the Turbine 2 requests are retrieved in order and with respect to
     # capability limitations and anything outside of the submitted capabilties is None
-    manager.halt_requests_for_system(turbine2)
+    manager.invalidate_system(turbine2)
+    manager.interrupt_system(turbine2)
     request = manager.get_request_by_system(
         ["LCN", "CAB", "DSV", "RMT", "DRN"], turbine2.id
     )
@@ -316,12 +315,14 @@ def test_get_requests(env_setup):
     manager.enable_requests_for_system(turbine2)
 
     request = manager.get_request_by_system(["CTV"], turbine2.id)
-    manager.halt_requests_for_system(turbine2)
+    manager.invalidate_system(turbine2)
+    manager.interrupt_system(turbine2)
     assert request.value == annual_reset2
     manager.enable_requests_for_system(turbine2)
 
     request = manager.get_request_by_system(capability_list, turbine2.id)
-    manager.halt_requests_for_system(turbine2)
+    manager.invalidate_system(turbine2)
+    manager.interrupt_system(turbine2)
     assert request.value == minor_repair2
     manager.enable_requests_for_system(turbine2)
 
@@ -334,7 +335,8 @@ def test_get_requests(env_setup):
     assert request is None
 
     # Activate turbine 3 and check that its medium repair is the next in the list
-    manager.halt_requests_for_system(turbine3)
+    manager.invalidate_system(turbine3)
+    manager.interrupt_system(turbine3)
     manager.enable_requests_for_system(turbine3)
     request = manager.get_request_by_severity(capability_list, 3)
     assert request.value == medium_repair3

--- a/tests/test_service_equipment.py
+++ b/tests/test_service_equipment.py
@@ -2025,11 +2025,10 @@ def test_unscheduled_service_equipment_call(env_setup_full_profile):
     assert hlv.current_system == "S00T2"
 
     # Ensure it's still here at the end, accounting for completing its last request
-    timeout += 30 * 24 + 10.5
+    timeout += 30 * 24 + 10 + 15 / 60
     env.run(timeout)
-    assert hlv.onsite is hlv.at_site is hlv.transferring_crew is True
-    assert hlv.at_port is hlv.enroute is False
-    assert hlv.at_system
+    assert hlv.onsite is hlv.at_site is hlv.at_system is True
+    assert hlv.transferring_crew is hlv.at_port is hlv.enroute is False
     assert hlv.current_system == "S00T3"
 
     # Check that it's gone

--- a/tests/test_service_equipment.py
+++ b/tests/test_service_equipment.py
@@ -2003,9 +2003,20 @@ def test_unscheduled_service_equipment_call(env_setup_full_profile):
     # The first HLV call is at 14012.2435309168 hours when S00T2's generator has a
     # catastrophic failure putting the windfarm at 83.3% operations, which is less than
     # the 90% threshold. However, because the timing will be delayed during repairs,
-    # realized timeout will be at 14163.758253
-    timeout = 14163.758253
+    # realized timeout will be at 14185.753253
+    timeout = 14185.753253
     env.run(timeout + 1)
+    # For checking in on the actual timing when it eventually changes
+    # df = env.load_events_log_dataframe()
+    # print(
+    #     df.loc[
+    #         df.agent == "Heavy Lift Vessel",
+    #         [
+    #             "env_datetime", "env_time", "agent", "action", "reason", "additional",
+    #             "duration", "system_id", "part_id", "request_id"
+    #         ]
+    #     ].tail(20).to_string()
+    # )
     assert hlv.enroute
     assert (
         hlv.transferring_crew
@@ -2029,7 +2040,7 @@ def test_unscheduled_service_equipment_call(env_setup_full_profile):
     env.run(timeout)
     assert hlv.onsite is hlv.at_site is hlv.at_system is True
     assert hlv.transferring_crew is hlv.at_port is hlv.enroute is False
-    assert hlv.current_system == "S00T1"
+    assert hlv.current_system == "S00T2"
 
     # Check that it's gone
     timeout += 24 + 15 / 60

--- a/tests/test_service_equipment.py
+++ b/tests/test_service_equipment.py
@@ -2003,8 +2003,8 @@ def test_unscheduled_service_equipment_call(env_setup_full_profile):
     # The first HLV call is at 14012.2435309168 hours when S00T2's generator has a
     # catastrophic failure putting the windfarm at 83.3% operations, which is less than
     # the 90% threshold. However, because the timing will be delayed during repairs,
-    # realized timeout will be at 14149.743531
-    timeout = 14149.743531
+    # realized timeout will be at 14163.758253
+    timeout = 14163.758253
     env.run(timeout + 1)
     assert hlv.enroute
     assert (
@@ -2029,9 +2029,9 @@ def test_unscheduled_service_equipment_call(env_setup_full_profile):
     env.run(timeout)
     assert hlv.onsite is hlv.at_site is hlv.at_system is True
     assert hlv.transferring_crew is hlv.at_port is hlv.enroute is False
-    assert hlv.current_system == "S00T3"
+    assert hlv.current_system == "S00T1"
 
     # Check that it's gone
-    timeout += 15 / 60
-    env.run(timeout)
+    timeout += 24 + 15 / 60
+    env.run(timeout + 24)
     assert hlv.onsite is False

--- a/tests/test_service_equipment.py
+++ b/tests/test_service_equipment.py
@@ -2003,8 +2003,8 @@ def test_unscheduled_service_equipment_call(env_setup_full_profile):
     # The first HLV call is at 14012.2435309168 hours when S00T2's generator has a
     # catastrophic failure putting the windfarm at 83.3% operations, which is less than
     # the 90% threshold. However, because the timing will be delayed during repairs,
-    # realized timeout will be at 14739.73 hours
-    timeout = 14739.73
+    # realized timeout will be at 14149.743531
+    timeout = 14149.743531
     env.run(timeout + 1)
     assert hlv.enroute
     assert (
@@ -2019,17 +2019,20 @@ def test_unscheduled_service_equipment_call(env_setup_full_profile):
 
     # Test that the HLV was successfully mobilized
     timeout += 60 * 24
-    timeout += 3.27  # weather delay
     env.run(timeout + 1 / 60)
-    print(env.now)
     assert hlv.transferring_crew is hlv.at_site is hlv.at_system is hlv.onsite is True
     assert hlv.enroute is hlv.at_port is False
     assert hlv.current_system == "S00T2"
 
-    # Ensure it's still here at the end
-    timeout += 30 * 24 - 1 / 60
+    # Ensure it's still here at the end, accounting for completing its last request
+    timeout += 30 * 24 + 10.5
     env.run(timeout)
-    assert hlv.onsite is hlv.at_site is True
-    assert hlv.transferring_crew is hlv.at_port is hlv.enroute is False
+    assert hlv.onsite is hlv.at_site is hlv.transferring_crew is True
+    assert hlv.at_port is hlv.enroute is False
     assert hlv.at_system
-    assert hlv.current_system == "S00T1"
+    assert hlv.current_system == "S00T3"
+
+    # Check that it's gone
+    timeout += 15 / 60
+    env.run(timeout)
+    assert hlv.onsite is False

--- a/wombat/core/environment.py
+++ b/wombat/core/environment.py
@@ -291,6 +291,27 @@ class WombatEnvironment(simpy.Environment):
         self._events_buffer: list[dict] = []
         self._operations_buffer: list[dict] = []
 
+    def get_random_seconds(self, low: int = 0, high: int = 10) -> float:
+        """Generate a random number of seconds to wait, between :py:attr:`low` and
+        :py:attr:`high`.
+
+        Parameters
+        ----------
+        low : int, optional
+            Minimum number of seconds to wait, by default 0.
+        high : int, optional
+            Maximum number of seconds to wait, by default 10.
+
+        Returns
+        -------
+        float
+            Number of seconds to wait.
+        """
+        seconds_to_wait, *_ = (
+            self.random_generator.integers(low=low, high=high, size=1) / 3600.0
+        )
+        return seconds_to_wait
+
     @property
     def simulation_time(self) -> datetime:
         """Current time within the simulation ("datetime" column within weather)."""

--- a/wombat/core/port.py
+++ b/wombat/core/port.py
@@ -414,6 +414,7 @@ class Port(RepairsMixin, FilterStore):
         system = self.windfarm.system(system_id)
         yield system.servicing_queue
         self.manager.invalidate_system(system)
+        self.invalid_systems.append(system_id)
 
         # If the system is already undergoing repairs from other servicing equipment,
         # then wait until it's done being serviced

--- a/wombat/core/port.py
+++ b/wombat/core/port.py
@@ -411,9 +411,6 @@ class Port(RepairsMixin, FilterStore):
 
         # Add the requested system to the list of systems undergoing or registered to be
         # undergoing repairs, so this method can't be run again on the same system
-        system = self.windfarm.system(system_id)
-        yield system.servicing_queue
-        self.manager.invalidate_system(system)
         self.invalid_systems.append(system_id)
 
         # If the system is already undergoing repairs from other servicing equipment,
@@ -424,10 +421,7 @@ class Port(RepairsMixin, FilterStore):
         turbine_request = self.turbine_manager.request()
 
         yield turbine_request & servicing
-        seconds_to_wait, *_ = (
-            self.env.random_generator.integers(low=0, high=30, size=1) / 3600.0
-        )
-        yield self.env.timeout(seconds_to_wait)
+        yield self.env.timeout(self.env.get_random_seconds())
         yield self.windfarm.system(system_id).servicing
 
         # Request a tugboat to retrieve the turbine

--- a/wombat/core/repair_management.py
+++ b/wombat/core/repair_management.py
@@ -485,16 +485,22 @@ class RepairManager(FilterStore):
         # criteria and acting on the request before it's processed
         return None
 
-    def invalidate_system(self, system: System | Cable) -> None:
+    def invalidate_system(self, system: System | Cable | str) -> None:
         """Disables the ability for servicing equipment to service a specific system,
         sets the turbine status to be in servicing, and interrupts all the processes
         to turn off operations.
 
         Parameters
         ----------
-        system_id : str
-            The system to disable repairs.
+        system : Syste | Cable | str
+            The system, cable, or ``str`` id of one to disable repairs.
         """
+        if isinstance(system, str):
+            if "::" in system:
+                system = self.windfarm.cable(system)
+            else:
+                system = self.windfarm.system(system)
+
         if system.id not in self.invalid_systems and system.servicing.triggered:
             system.servicing_queue = self.env.event()
             self.invalid_systems.append(system.id)

--- a/wombat/core/repair_management.py
+++ b/wombat/core/repair_management.py
@@ -190,6 +190,9 @@ class RepairManager(FilterStore):
         # have an operating reduction threshold to meet at this time
         if "TOW" in request.details.service_equipment:
             if request.system_id not in self.port.invalid_systems:
+                system = self.windfarm.system(request.system_id)
+                yield system.servicing_queue & system.servicing
+                self.manager.invalidate_system(request.system_id)
                 yield self.env.process(self.port.run_tow_to_port(request))
             return
 
@@ -249,6 +252,9 @@ class RepairManager(FilterStore):
         # a requests-based threshold to meet at this time
         if "TOW" in request.details.service_equipment:
             if request.system_id not in self.port.invalid_systems:
+                system = self.windfarm.system(request.system_id)
+                yield system.servicing_queue & system.servicing
+                self.invalidate_system(system)
                 yield self.env.process(self.port.run_tow_to_port(request))
             return
 

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -1550,6 +1550,16 @@ class ServiceEquipment(RepairsMixin):
             self.crew_transfer(system, subassembly, request, to_system=False)
         )
         if shift_delay or hours_required > 0:
+            # For 24-hour shifts, we just need to start back at the top
+            if self.settings.non_stop_shift:
+                yield self.env.process(
+                    self.in_situ_repair(
+                        request,
+                        time_processed=hours_processed + time_processed,
+                        prior_operation_level=starting_operational_level,
+                    )
+                )
+                return
             shared_logging.update(
                 system_ol=system.operating_level, part_ol=subassembly.operating_level
             )

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -370,15 +370,6 @@ class ServiceEquipment(RepairsMixin):
         all_clear = (wind <= max_wind) & (wave <= max_wave)
         return dt, hour, all_clear
 
-    def _avoid_timing_collisions(self) -> Generator:
-        """Wait a random number of seconds, between 0 and 10, to avoid requests for the
-        same system and therefore a timing collision.
-        """
-        seconds_to_wait, *_ = (
-            self.env.random_generator.integers(low=0, high=10, size=1) / 3600.0
-        )
-        yield self.env.timeout(seconds_to_wait)
-
     def get_speed(self, tow: bool = False) -> float:
         """Determines the appropriate speed that the servicing equipment should be
         traveling at for towing or traveling, and if the timeframe is during a reduced

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -412,7 +412,8 @@ class ServiceEquipment(RepairsMixin):
         simpy.resources.store.FilterStoreGet
             The next ``RepairRequest`` to be processed.
         """
-        yield self.env.process(self._avoid_timing_collisions())
+        # Wait between 1 and 10 seconds to ensure a tow-to-port repair is always first
+        yield self.env.timeout(self.env.get_random_seconds(low=1))
 
         if self.settings.method == "turbine":
             request = self.manager.get_request_by_system(self.settings.capability)
@@ -1788,10 +1789,7 @@ class ServiceEquipment(RepairsMixin):
             else:
                 system = self.windfarm.system(request.system_id)  # type: ignore
             yield system.servicing
-            seconds_to_wait, *_ = (
-                self.env.random_generator.integers(low=0, high=30, size=1) / 3600.0
-            )
-            yield self.env.timeout(seconds_to_wait)
+            yield self.env.timeout(self.env.get_random_seconds(low=1))
             yield system.servicing
 
         while True:

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -1944,7 +1944,7 @@ class ServiceEquipment(RepairsMixin):
 
         # Reset the turbine back to operating and return to port
         reset_system_operations(system, subassembly_resets)
-        self.manager.enable_requests_for_system(system)
+        self.manager.enable_requests_for_system(system, tow=True)
         yield self.env.process(
             self.travel(
                 "site",

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -423,12 +423,7 @@ class ServiceEquipment(RepairsMixin):
             yield request
         else:
             request = request.value
-            sid = request.system_id
-            is_cable = request.cable
-            system = self.windfarm.cable(sid) if is_cable else self.windfarm.system(sid)
-            if TYPE_CHECKING:
-                assert isinstance(system, (System, Cable))
-            self.manager.invalidate_system(system)
+            self.manager.invalidate_system(request.system_id)
             yield request
 
     def enable_string_operations(self, cable: Cable) -> None:

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -984,7 +984,7 @@ class ServiceEquipment(RepairsMixin):
         future_time = self.env.simulation_time + timedelta(hours=hours)
         is_shift = self._is_workshift(future_time.hour)
         if (
-            (not is_shift or hours_to_shift_end > hours)
+            (not is_shift or hours > hours_to_shift_end)
             and end != "port"
             and not self.at_port
         ):
@@ -1426,7 +1426,9 @@ class ServiceEquipment(RepairsMixin):
 
             yield self.env.process(
                 self.in_situ_repair(
-                    request, prior_operation_level=starting_operational_level
+                    request,
+                    prior_operation_level=starting_operational_level,
+                    initial=initial,
                 )
             )
             return

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -370,6 +370,15 @@ class ServiceEquipment(RepairsMixin):
         all_clear = (wind <= max_wind) & (wave <= max_wave)
         return dt, hour, all_clear
 
+    def _avoid_collisions(self) -> Generator:
+        """Wait a random number of seconds, between 0 and 10, to avoid requests for the
+        same system and therefore a timing collision.
+        """
+        seconds_to_wait, *_ = (
+            self.env.random_generator.integers(low=0, high=10, size=1) / 3600.0
+        )
+        yield self.env.timeout(seconds_to_wait)
+
     def get_speed(self, tow: bool = False) -> float:
         """Determines the appropriate speed that the servicing equipment should be
         traveling at for towing or traveling, and if the timeframe is during a reduced
@@ -403,11 +412,7 @@ class ServiceEquipment(RepairsMixin):
         simpy.resources.store.FilterStoreGet
             The next ``RepairRequest`` to be processed.
         """
-        # Avoid requests for the same system and therefore a timing collision
-        seconds_to_wait, *_ = (
-            self.env.random_generator.integers(low=0, high=10, size=1) / 3600.0
-        )
-        yield self.env.timeout(seconds_to_wait)
+        self.env.process(self._avoid_collisions())
 
         if self.settings.method == "turbine":
             return self.manager.get_request_by_system(self.settings.capability)

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -1647,6 +1647,12 @@ class ServiceEquipment(RepairsMixin):
                     )
                 )
 
+            # Avoid requests for the same system and therefore a timing collision
+            seconds_to_wait, *_ = (
+                self.env.random_generator.integers(low=0, high=10, size=1) / 3600.0
+            )
+            yield self.env.timeout(seconds_to_wait)
+
             request = self.get_next_request()
             if request is None:
                 if not self.at_port:
@@ -1739,6 +1745,12 @@ class ServiceEquipment(RepairsMixin):
             return
 
         while True and self.env.now < charter_end_env_time:
+            # Avoid requests for the same system and therefore a timing collision
+            seconds_to_wait, *_ = (
+                self.env.random_generator.integers(low=0, high=10, size=1) / 3600.0
+            )
+            yield self.env.timeout(seconds_to_wait)
+
             request = self.get_next_request()
             if request is None:
                 yield self.env.process(
@@ -1823,8 +1835,12 @@ class ServiceEquipment(RepairsMixin):
                     )
                 )
 
-            # Wait one second to ensure there are no timing collisions
-            yield self.env.timeout(1.0 / 3600)
+            # Avoid requests for the same system and therefore a timing collision
+            seconds_to_wait, *_ = (
+                self.env.random_generator.integers(low=0, high=10, size=1) / 3600.0
+            )
+            yield self.env.timeout(seconds_to_wait)
+
             request = self.get_next_request()
             if request is None:
                 yield self.env.process(

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -1537,7 +1537,7 @@ class ServiceEquipment(RepairsMixin):
         yield self.env.process(
             self.crew_transfer(system, subassembly, request, to_system=False)
         )
-        if shift_delay:
+        if shift_delay or hours_required > 0:
             shared_logging.update(
                 system_ol=system.operating_level, part_ol=subassembly.operating_level
             )

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -403,6 +403,12 @@ class ServiceEquipment(RepairsMixin):
         simpy.resources.store.FilterStoreGet
             The next ``RepairRequest`` to be processed.
         """
+        # Avoid requests for the same system and therefore a timing collision
+        seconds_to_wait, *_ = (
+            self.env.random_generator.integers(low=0, high=10, size=1) / 3600.0
+        )
+        yield self.env.timeout(seconds_to_wait)
+
         if self.settings.method == "turbine":
             return self.manager.get_request_by_system(self.settings.capability)
         if self.settings.method == "severity":
@@ -1647,12 +1653,6 @@ class ServiceEquipment(RepairsMixin):
                     )
                 )
 
-            # Avoid requests for the same system and therefore a timing collision
-            seconds_to_wait, *_ = (
-                self.env.random_generator.integers(low=0, high=10, size=1) / 3600.0
-            )
-            yield self.env.timeout(seconds_to_wait)
-
             request = self.get_next_request()
             if request is None:
                 if not self.at_port:
@@ -1745,12 +1745,6 @@ class ServiceEquipment(RepairsMixin):
             return
 
         while True and self.env.now < charter_end_env_time:
-            # Avoid requests for the same system and therefore a timing collision
-            seconds_to_wait, *_ = (
-                self.env.random_generator.integers(low=0, high=10, size=1) / 3600.0
-            )
-            yield self.env.timeout(seconds_to_wait)
-
             request = self.get_next_request()
             if request is None:
                 yield self.env.process(
@@ -1834,12 +1828,6 @@ class ServiceEquipment(RepairsMixin):
                         }
                     )
                 )
-
-            # Avoid requests for the same system and therefore a timing collision
-            seconds_to_wait, *_ = (
-                self.env.random_generator.integers(low=0, high=10, size=1) / 3600.0
-            )
-            yield self.env.timeout(seconds_to_wait)
 
             request = self.get_next_request()
             if request is None:

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -403,8 +403,8 @@ class ServiceEquipment(RepairsMixin):
         simpy.resources.store.FilterStoreGet
             The next ``RepairRequest`` to be processed.
         """
-        # Wait between 1 and 10 seconds to ensure a tow-to-port repair is always first
-        yield self.env.timeout(self.env.get_random_seconds(low=1))
+        # Wait between 2 and 10 seconds to ensure a tow-to-port repair is always first
+        yield self.env.timeout(self.env.get_random_seconds(low=2))
 
         if self.settings.method == "turbine":
             request = self.manager.get_request_by_system(self.settings.capability)
@@ -1657,6 +1657,7 @@ class ServiceEquipment(RepairsMixin):
                     )
                 )
 
+            yield self.env.timeout(self.env.get_random_seconds(low=2))
             _, request = self.get_next_request()
             if request is None:
                 if not self.at_port:
@@ -1780,7 +1781,7 @@ class ServiceEquipment(RepairsMixin):
             else:
                 system = self.windfarm.system(request.system_id)  # type: ignore
             yield system.servicing
-            yield self.env.timeout(self.env.get_random_seconds(low=1))
+            yield self.env.timeout(self.env.get_random_seconds(low=2))
             yield system.servicing
 
         while True:

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -975,9 +975,19 @@ class ServiceEquipment(RepairsMixin):
 
         # If the the equipment will arive after the shift is over, then it must travel
         # back to port (if needed), and wait for the next shift
+        if self.settings.non_stop_shift:
+            hours_to_shift_end = hours
+        else:
+            hours_to_shift_end = hours_until_future_hour(
+                self.env.simulation_time, self.settings.workday_end
+            )
         future_time = self.env.simulation_time + timedelta(hours=hours)
         is_shift = self._is_workshift(future_time.hour)
-        if not is_shift and end != "port" and not self.at_port:
+        if (
+            (not is_shift or hours_to_shift_end > hours)
+            and end != "port"
+            and not self.at_port
+        ):
             kw = {
                 "additional": "insufficient time to complete travel before end of the shift"  # noqa: disabl#501
             }

--- a/wombat/windfarm/system/cable.py
+++ b/wombat/windfarm/system/cable.py
@@ -92,11 +92,13 @@ class Cable:
 
         self.operating_level = 1.0
         self.servicing = self.env.event()
+        self.servicing_queue = self.env.event()
         self.downstream_failure = self.env.event()
         self.broken = self.env.event()
 
         # Ensure events start as processed and inactive
         self.servicing.succeed()
+        self.servicing_queue.succeed()
         self.downstream_failure.succeed()
         self.broken.succeed()
 

--- a/wombat/windfarm/system/system.py
+++ b/wombat/windfarm/system/system.py
@@ -62,10 +62,12 @@ class System:
         self.capacity = subassemblies["capacity_kw"]
         self.subassemblies: list[Subassembly] = []
         self.servicing = self.env.event()
+        self.servicing_queue = self.env.event()
         self.cable_failure = self.env.event()
 
         # Ensure servicing statuses starts as processed and inactive
         self.servicing.succeed()
+        self.servicing_queue.succeed()
         self.cable_failure.succeed()
 
         system = system.lower().strip()


### PR DESCRIPTION
This PR addresses a series of logic holes:
- Servicing equipment can no longer travel when their expected finish time is in the following shift, but after the original shift's end time
- Repairs with delays that are incomplete at the end of the original forecast window now consistently register as having a shift delay instead of being complete
- Systems wait until a servicing equipment has arrived and is going to transfer the crew to interrupt it and shut it down, rather than at the onset of traveling to the system.

See the changelog for complete details. All changes result in a small net positive increase in availability due to better resolved timing of shut downs and repairs.