### PR TITLE
Bug Fix: Keep logged events within the timing bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Repairs that had a weather delay extended repairs past the end of the shift now properly extend the repair into future shifts instead of completing early. This has a small negative impact on availability because that means some repairs can take longer than they had originally.
 - Traveling to a system for a repair where the timing extends beyond the end of the shift, but into the next shift, is now registered as a shift delay just like travel weather delays that extend beyond the end of the current shift but before the start of the next shift. This has a small positive impact on availability because a turbine or cable may not start being repaired until weather is more consistently clear, rather than starting it and extending it for many shifts.
 - `Windfarm.cable()` now correctly identifies 2 and 3 length cable naming conventions to differentiate which version of the cable id is being retrieved.
+- An edge case where events occurred just after the end of a simulation has been resolved by checking the datetime stamp of that event and not adding any action log to the simulation that is after the `WombatEnvironment.end_datetime`.
 
 ### General Updates
 

--- a/wombat/core/environment.py
+++ b/wombat/core/environment.py
@@ -680,9 +680,10 @@ class WombatEnvironment(simpy.Environment):
             )
         total_labor_cost = hourly_labor_cost + salary_labor_cost
         total_cost = total_labor_cost + equipment_cost + materials_cost
+        now = self.simulation_time
         row = {
             "datetime": dt.datetime.now(),
-            "env_datetime": self.simulation_time,
+            "env_datetime": now,
             "env_time": self.now,
             "system_id": system_id,
             "system_name": system_name,
@@ -705,7 +706,10 @@ class WombatEnvironment(simpy.Environment):
             "total_labor_cost": total_labor_cost,
             "total_cost": total_cost,
         }
-        self._events_buffer.append(row)
+        # Don't log the initiation of a crew transfer that can forced at the end of an
+        # operation but happens to be after the end of the simulation
+        if now <= self.end_datetime:
+            self._events_buffer.append(row)
 
     def _log_actions(self):
         """Writes the action log items every 8000 hours."""


### PR DESCRIPTION
This PR resolves an edge case where a crew transfer gets initiated for midnight after the end of the last day of the simulation by checking the timestamp in the environment's logging method and ignoring any log occurring after that.