### PR TITLE
Patch: Fix bad repository link

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -32,7 +32,7 @@ bibtex_bibfiles:
 
 # Information about where the book exists on the web
 repository:
-  url: https://github.com/NREL/WAVES
+  url: https://github.com/WISDEM/WOMBAT
   path_to_book: docs  # Optional path to your book, relative to the repository root
   branch: main  # Which branch of the repository should be used when creating links (optional)
 


### PR DESCRIPTION
This PR fixes a link where the documention's GitHub source link incorrectly pointed to the NREL/WAVES repository.