### PR TITLE
Maintenance: Adopt Ruff Formatter and Pyupgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,12 +8,20 @@ repos:
           name: isort
           stages: [commit]
 
-- repo: https://github.com/psf/black
-  rev: 23.12.0
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.15.0
   hooks:
-  - id: black
-    name: black
+  - id: pyupgrade
+    args: [--py39-plus]
     stages: [commit]
+
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: v0.1.8
+  hooks:
+  - id: ruff
+    args: [--fix]
+  - id: ruff-format
+    types_or: [python, pyi, jupyter]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: 'v1.7.1'  # Use the sha / tag you want to point at
@@ -22,11 +30,6 @@ repos:
     entry: mypy --install-types --non-interactive --config-file .mypy.ini
     exclude: (^docs/|^tests/)
     additional_dependencies: ["types-python-dateutil", "types-attrs", "types-PyYAML"]
-
-- repo: https://github.com/numpy/numpydoc
-  rev: 'v1.6.0'
-  hooks:
-    - id: numpydoc-validation
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.5.0
@@ -42,13 +45,6 @@ repos:
   -   id: mixed-line-ending
   -   id: pretty-format-json
       args: [--autofix]
-
-
-- repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.1.8
-  hooks:
-  - id: ruff
-    args: [--fix]
 
 # -   repo: local
 #     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,11 @@ repos:
     exclude: (^docs/|^tests/)
     additional_dependencies: ["types-python-dateutil", "types-attrs", "types-PyYAML"]
 
+- repo: https://github.com/numpy/numpydoc
+  rev: 'v1.6.0'
+  hooks:
+    - id: numpydoc-validation
+
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.5.0
   hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased (TBD)
+
+- Replace the `black` formatter with `ruff`.
+- Adopt `pyupgrade` to ensure modern Python language usage.
+
 ## v0.9.2 (13 November 2023)
 
 ### General

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Replace the `black` formatter with `ruff`.
 - Adopt `pyupgrade` to ensure modern Python language usage.
+- Add the NumPy 2.0 integration tool to Ruf.
 
 ## v0.9.2 (13 November 2023)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,8 @@ dev = [
     "pytest>=7",
     "pytest-cov>=4",
     "mypy==0.991",
-    "ruff==0.0.246",
+    "ruff>=0.2",
+    "numpydoc",
 ]
 docs = [
     "jupyter-book>=0.15",
@@ -184,16 +185,26 @@ exclude = '''
 )/
 '''
 
+[tool.numpydoc_validation]
+checks = [
+  "all",
+  "ES01",
+  "SA01",
+  "EX01",
+]
+exclude = ["*__pycache__"]
+
 [tool.ruff]
 src = ["wombat", "tests"]
 line-length = 88
 target-version = "py39"
-ignore-init-module-imports = true
 
+[tool.ruff.lint]
 # See https://github.com/charliermarsh/ruff#supported-rules
 # for rules included and matching to prefix.
 # TODO: "FBT", "B", "PIE, "T20", "SIM", "PTH", "PD", "I", "PL"
-select = ["F", "E", "W", "C4", "D", "UP"]
+ignore-init-module-imports = true
+select = ["F", "E", "W", "C4", "D", "UP", "NPY201"]
 
 # D205: not using summary lines and descriptions, just descriptions
 # D401: don't believe enough in imperative mode to make all the changes currently
@@ -229,7 +240,7 @@ exclude = [
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "setup.py" = ["D104"]
 "library/__init__.py" = ["D104"]
 "library/code_comparison/__init__.py" = ["D104"]
@@ -281,5 +292,5 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 "wombat/windfarm/__init__.py" = ["F401"]
 "wombat/windfarm/system/__init__.py" = ["F401"]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,13 +65,12 @@ changelog = "https://github.com/WISDEM/WOMBAT/blob/main/CHANGELOG.md"
 [project.optional-dependencies]
 dev = [
     "pre-commit>=2.20",
-    "black>=22.1",
     "isort>=5.10",
     "pytest>=7",
     "pytest-cov>=4",
     "mypy==0.991",
     "ruff>=0.2",
-    "numpydoc",
+    "pyupgrade",
 ]
 docs = [
     "jupyter-book>=0.15",
@@ -165,26 +164,6 @@ length_sort = true
 lines_after_imports = 2
 line_length = 88
 
-
-[tool.black]
-target-version=["py39", "py310"]
-line-length=88
-
-include = '\.pyi?$'
-exclude = '''
-/(
-    \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | buck-out
-  | build
-  | dist
-)/
-'''
-
 [tool.numpydoc_validation]
 checks = [
   "all",
@@ -198,6 +177,7 @@ exclude = ["*__pycache__"]
 src = ["wombat", "tests"]
 line-length = 88
 target-version = "py39"
+fix = true
 
 [tool.ruff.lint]
 # See https://github.com/charliermarsh/ruff#supported-rules

--- a/wombat/core/data_classes.py
+++ b/wombat/core/data_classes.py
@@ -250,7 +250,9 @@ def check_start_stop_dates(
 
 
 def valid_hour(
-    instance: Any, attribute: Attribute, value: int  # pylint: disable=W0613
+    instance: Any,
+    attribute: Attribute,
+    value: int,  # pylint: disable=W0613
 ) -> None:
     """Validate that the input is a valid time or null value (-1).
 
@@ -275,7 +277,9 @@ def valid_hour(
 
 
 def valid_reduction(
-    instance, attribute: Attribute, value: int | float  # pylint: disable=W0613
+    instance,
+    attribute: Attribute,
+    value: int | float,  # pylint: disable=W0613
 ) -> None:
     """Check to see if the reduction factor is between 0 and 1, inclusive.
 

--- a/wombat/windfarm/windfarm.py
+++ b/wombat/windfarm/windfarm.py
@@ -345,7 +345,8 @@ class Windfarm:
                 downstream=graph.nodes[s_id]["connection"],
             )
         self.wind_farm_map = WindFarmMap(
-            substation_map=wind_map, export_cables=export  # type: ignore
+            substation_map=wind_map,
+            export_cables=export,  # type: ignore
         )
 
     def finish_setup(self) -> None:


### PR DESCRIPTION
This PR replaces the `black` formatter with the `ruff` formatter, and adopts `pyupgrade`.