### PR TITLE
Bug Fix: Operating Reductions Inconsistently Rest 

### DIFF
--- a/tests/test_data_classes.py
+++ b/tests/test_data_classes.py
@@ -26,10 +26,10 @@ from wombat.core.data_classes import (
     UnscheduledServiceEquipmentData,
     valid_hour,
     convert_to_list,
-    valid_reduction,
     annual_date_range,
     clean_string_input,
     convert_to_list_lower,
+    validate_0_1_inclusive,
     convert_ratio_to_absolute,
 )
 
@@ -151,14 +151,16 @@ def test_valid_hour():
     assert hour.hour == 24
 
 
-def test_valid_reduction():
-    """Tests the ``valid_reduction`` validator."""
+def test_validate_0_1_inclusive():
+    """Tests the ``validate_0_1_inclusive`` validator."""
 
     @attr.s(auto_attribs=True)
     class ReductionClass:
-        """Dummy class for testing ``valid_reduction``."""
+        """Dummy class for testing ``validate_0_1_inclusive``."""
 
-        speed_reduction: int = attr.ib(converter=float, validator=valid_reduction)
+        speed_reduction: int = attr.ib(
+            converter=float, validator=validate_0_1_inclusive
+        )
 
     # Test the fringes
     with pytest.raises(ValueError):

--- a/wombat/core/data_classes.py
+++ b/wombat/core/data_classes.py
@@ -278,7 +278,7 @@ def valid_hour(
         raise ValueError(f"Input {attribute.name} must be between 0 and 24, inclusive.")
 
 
-def valid_reduction(
+def validate_0_1_inclusive(
     instance,
     attribute: Attribute,
     value: int | float,  # pylint: disable=W0613
@@ -292,8 +292,8 @@ def valid_reduction(
     """
     if value < 0 or value > 1:
         raise ValueError(
-            f"Input for {attribute.name}'s `speed_reduction_factor` must be between"
-            " 0 and 1, inclusive."
+            f"Input for {attribute.name} must be between 0 and 1, inclusive, not:"
+            f" {value=}."
         )
 
 
@@ -650,6 +650,9 @@ class RepairRequest(FromDictMixin):
     cable: bool = field(default=False, converter=bool, kw_only=True)
     upstream_turbines: list[str] = field(default=Factory(list), kw_only=True)
     upstream_cables: list[str] = field(default=Factory(list), kw_only=True)
+    prior_operating_level: float = field(
+        default=1, kw_only=True, validator=validate_0_1_inclusive
+    )
     request_id: str = field(init=False)
 
     def assign_id(self, request_id: str) -> None:
@@ -1068,7 +1071,7 @@ class ScheduledServiceEquipmentData(FromDictMixin, DateLimitsMixin):
     workday_end: int = field(default=-1, converter=int, validator=valid_hour)
     crew_transfer_time: float = field(converter=float, default=0.0)
     speed_reduction_factor: float = field(
-        default=0.0, converter=float, validator=valid_reduction
+        default=0.0, converter=float, validator=validate_0_1_inclusive
     )
     port_distance: float = field(default=0.0, converter=float)
     onsite: bool = field(default=False, converter=bool)
@@ -1287,7 +1290,7 @@ class UnscheduledServiceEquipmentData(FromDictMixin, DateLimitsMixin):
     workday_end: int = field(default=-1, converter=int, validator=valid_hour)
     crew_transfer_time: float = field(converter=float, default=0.0)
     speed_reduction_factor: float = field(
-        default=0.0, converter=float, validator=valid_reduction
+        default=0.0, converter=float, validator=validate_0_1_inclusive
     )
     port_distance: float = field(default=0.0, converter=float)
     onsite: bool = field(default=False, converter=bool)

--- a/wombat/core/repair_management.py
+++ b/wombat/core/repair_management.py
@@ -532,7 +532,9 @@ class RepairManager(FilterStore):
                 self.systems_waiting_for_tow.index(system.id)
             )
 
-    def interrupt_system(self, system: System | Cable) -> None:
+    def interrupt_system(
+        self, system: System | Cable, replacement: bool = False
+    ) -> None:
         """Sets the turbine status to be in servicing, and interrupts all the processes
         to turn off operations.
 
@@ -540,10 +542,13 @@ class RepairManager(FilterStore):
         ----------
         system_id : str
             The system to disable repairs.
+        replacement: bool, optional
+            Indicates if the interruption is caused a result of a replacement event.
+            Defaults to False.
         """
         if system.servicing.triggered and system.id in self.invalid_systems:
             system.servicing = self.env.event()
-            system.interrupt_all_subassembly_processes()
+            system.interrupt_all_subassembly_processes(replacement=replacement)
         else:
             raise RuntimeError(
                 f"{self.env.simulation_time} {system.id} already being serviced"

--- a/wombat/windfarm/system/subassembly.py
+++ b/wombat/windfarm/system/subassembly.py
@@ -83,7 +83,9 @@ class Subassembly:
         """
         self.processes = dict(self._create_processes())
 
-    def interrupt_processes(self, origin: Subassembly | None = None) -> None:
+    def interrupt_processes(
+        self, origin: Subassembly | None = None, replacement: bool = False
+    ) -> None:
         """Interrupts all of the running processes within the subassembly except for the
         process associated with failure that triggers the catastrophic failure.
 
@@ -94,17 +96,21 @@ class Subassembly:
             from a subassembly shutdown event. If provided, and it is the same as the
             current subassembly, then a try/except flow is used to ensure the process
             that initiated the shutdown is not interrupting itself.
+        replacement: bool, optional
+            Indicates if the interruption is caused a result of a replacement event.
+            Defaults to False.
         """
+        cause = "replacement" if replacement else "failure"
         if origin is not None and id(origin) == id(self):
             for _, process in self.processes.items():
                 try:
-                    process.interrupt()
+                    process.interrupt(cause=cause)
                 except RuntimeError:  # Process initiating process can't be interrupted
                     pass
             return
 
         for _, process in self.processes.items():
-            process.interrupt()
+            process.interrupt(cause=cause)
 
     def interrupt_all_subassembly_processes(self) -> None:
         """Thin wrapper for ``system.interrupt_all_subassembly_processes``."""
@@ -120,6 +126,7 @@ class Subassembly:
             The maintenance or failure event that triggers a ``RepairRequest``.
         """
         which = "maintenance" if isinstance(action, Maintenance) else "repair"
+        current_ol = self.operating_level
         self.operating_level *= 1 - action.operation_reduction
         if action.operation_reduction == 1:
             self.broken = self.env.event()
@@ -140,6 +147,7 @@ class Subassembly:
             subassembly_name=self.name,
             severity_level=action.level,
             details=action,
+            prior_operating_level=current_ol,
         )
         repair_request = self.system.repair_manager.register_request(repair_request)
         self.env.log_action(
@@ -195,14 +203,16 @@ class Subassembly:
                         hours_to_next = 0
                         self.trigger_request(maintenance)
 
-                    except simpy.Interrupt:
-                        if not self.broken.triggered:
-                            # The subassembly had to restart the maintenance cycle
-                            hours_to_next = 0
-                        else:
-                            # A different process failed, so subtract the elapsed time
-                            # only if it had started to be processed
-                            hours_to_next -= 0 if start == -1 else self.env.now - start
+                    except simpy.Interrupt as i:
+                        # if not self.broken.triggered:
+                        #     # The subassembly had to restart the maintenance cycle
+                        #     hours_to_next = 0
+                        # else:
+                        #     # A different process failed, so subtract the elapsed time
+                        #     # only if it had started to be processed
+                        if i.cause == "replacement":
+                            return
+                        hours_to_next -= 0 if start == -1 else self.env.now - start
 
     def run_single_failure(self, failure: Failure) -> Generator:
         """Runs a process to trigger one type of failure repair request throughout the
@@ -241,11 +251,13 @@ class Subassembly:
                         hours_to_next = 0
                         self.trigger_request(failure)
 
-                    except simpy.Interrupt:
-                        if not self.broken.triggered:
-                            # The subassembly had to be replaced so reset the timing
-                            hours_to_next = 0
-                        else:
-                            # A different process failed, so subtract the elapsed time
-                            # only if it had started to be processed
-                            hours_to_next -= 0 if start == -1 else self.env.now - start
+                    except simpy.Interrupt as i:
+                        # if not self.broken.triggered:
+                        #     # The subassembly had to be replaced so reset the timing
+                        #     hours_to_next = 0
+                        # else:
+                        #     # A different process failed, so subtract the elapsed time
+                        #     # only if it had started to be processed
+                        if i.cause == "replacement":
+                            return
+                        hours_to_next -= 0 if start == -1 else self.env.now - start

--- a/wombat/windfarm/system/system.py
+++ b/wombat/windfarm/system/system.py
@@ -162,7 +162,7 @@ class System:
             )
 
     def interrupt_all_subassembly_processes(
-        self, origin: Subassembly | None = None
+        self, origin: Subassembly | None = None, replacement: bool = False
     ) -> None:
         """Interrupts the running processes in all of the system's subassemblies.
 
@@ -171,9 +171,12 @@ class System:
         origin : Subassembly
             The subassembly that triggered the request, if the method call is coming
             from a subassembly shutdown event.
+        replacement: bool, optional
+            Indicates if the interruption is caused a result of a replacement event.
+            Defaults to False.
         """
         [
-            subassembly.interrupt_processes(origin=origin)  # type: ignore
+            subassembly.interrupt_processes(origin=origin, replacement=replacement)  # type: ignore
             for subassembly in self.subassemblies
         ]
 


### PR DESCRIPTION
This PR directly resolves #140 and another underlying issue causing persistent processes to timeout after they have been recreated following a replacement event.

To achieve this, the following changes have been implemented:
- original operating levels are tracked for 100% reduction failures
- replacement flag for interruptions are passed so that failure processes can't persist after a replacement event