### PR TITLE
Fix subassembly ID creation to not strip non-leading numerals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Replaces the `valid_reduction` attrs validator with `validate_0_1_inclusive` to reuse the logic in multiple places without duplicating checking methods.
 - Adds a `replacement` flag for interruption methods, so that a failure or replacement comment can be added as a cause for `simpy.process.interrupt`. This update allows the failure and maintenance processes to check if an interruption should cause the process to exit completely. Additionally, the forced exit ensures that processes can't persist after a replacement event when a process is recreated, which was happening in isolated cases.
 - Fixes a bug in `RepairManager.purge_subassemble_requests()` where the pending tows are cleared regardless of whether or not the focal subassembly is the cause of the tow, leading to a simulation failure.
+- Fixes a bug in `utilities/utilities.py:create_variable_from_string()` to operate in a way that is expected. The original method was removing all numerics, but only leading punctuation and numerics should be replaced, with any punctuation being replaced with an underscore.
 
 ## v0.9.3 (15 February 2024)
 

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -493,7 +493,6 @@ class ServiceEquipment(RepairsMixin):
             try:
                 subassembly.broken.succeed()
             except RuntimeError as e:
-                print(subassembly.system.id, repair.details.description)
                 raise e
         elif operation_reduction == 0:
             subassembly.operating_level = starting_operating_level

--- a/wombat/utilities/utilities.py
+++ b/wombat/utilities/utilities.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-import re
+from string import digits, punctuation
 from typing import Callable
 
 import numpy as np
@@ -57,11 +57,11 @@ def create_variable_from_string(string: str) -> str:
     'electrical_system'
 
     """
-    new_string = re.sub(
-        "[^0-9a-zA-Z]+",
-        "_",
-        re.sub(r"^\W+", "", re.sub("[^a-zA-Z]+$", "", string)),  # noqa: disable=W605
-    ).lower()
+    new_string = (
+        string.lstrip(punctuation + digits)
+        .translate(str.maketrans("", "", punctuation.replace("_", " ")))
+        .lower()
+    )
     return new_string
 
 


### PR DESCRIPTION
This PR fixes a previously unknown issue that modifies the `Subassembly.id` to rename subassemblies such as "mooring_1" to "mooring". This creates a naming overlap that doesn't causes errors unless there are replacement events, which then cause each identically named subassembly to have invalidated processes, rather than just the failing one. Subassembly IDs are now stripped of leading punctuation and digits and have all punctuation replaced with underscores.