### PR TITLE
Fix bad capability code in strategy map

### DIFF
--- a/wombat/core/data_classes.py
+++ b/wombat/core/data_classes.py
@@ -1605,7 +1605,7 @@ class StrategyMap:
         elif capability == "AHV":
             self.AHV.append(self.AHV.pop(ix))
         elif capability == "VSG":
-            self.VSG.append(self.AHV.pop(ix))
+            self.VSG.append(self.VSG.pop(ix))
         else:
             # This should not even be able to be reached
             raise ValueError(


### PR DESCRIPTION
This PR fixes an incorrect reference to "AHV" in `StrategyMap.move_equipment_to_end` where the "VSG" category moves a vessel in the "AHV" category, not "VSG".