### PR TITLE
Update `functool.cache` usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Fixes a bug in `utilities/utilities.py:create_variable_from_string()` to operate in a way that is expected. The original method was removing all numerics, but only leading punctuation and numerics should be replaced, with any punctuation being replaced with an underscore.
 - Adds additional inline comments for clarification on internal methods.
 - Update README.md to be inline with current conda and Python standards.
+- Fully adopts `functools.cache` now that older Python versions where
+  `functools.lru_cache` was the available caching method.
 
 ## v0.9.3 (15 February 2024)
 

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -3,6 +3,7 @@ to the operations of servicing equipment and the `ServiceEquipment` class that p
 the repair and transportation logic for scheduled, unscheduled, and unscheduled towing
 servicing equipment.
 """
+
 # TODO: NEED A SPECIFIC STARTUP METHOD
 from __future__ import annotations
 
@@ -11,6 +12,7 @@ from math import ceil
 from typing import TYPE_CHECKING, Any
 from pathlib import Path
 from datetime import timedelta
+from functools import cache
 from itertools import zip_longest
 from collections.abc import Generator
 
@@ -28,7 +30,7 @@ from wombat.core import (
     ServiceEquipmentData,
 )
 from wombat.windfarm import Windfarm
-from wombat.utilities import HOURS_IN_DAY, cache, hours_until_future_hour
+from wombat.utilities import HOURS_IN_DAY, hours_until_future_hour
 from wombat.core.mixins import RepairsMixin
 from wombat.core.library import load_yaml
 from wombat.windfarm.system import System

--- a/wombat/utilities/__init__.py
+++ b/wombat/utilities/__init__.py
@@ -1,6 +1,5 @@
 """Creates the utilities objects."""
 
-
 from .time import (
     HOURS_IN_DAY,
     HOURS_IN_YEAR,
@@ -10,4 +9,4 @@ from .time import (
     hours_until_future_hour,
 )
 from .logging import setup_logger, format_events_log_message
-from .utilities import IEC_power_curve, _mean, cache, create_variable_from_string
+from .utilities import IEC_power_curve, _mean, create_variable_from_string

--- a/wombat/utilities/utilities.py
+++ b/wombat/utilities/utilities.py
@@ -1,21 +1,13 @@
 """Provides various utility functions that don't fit within a common theme."""
 
-
 from __future__ import annotations
 
 from string import digits, punctuation
 from typing import Callable
+from functools import cache
 
 import numpy as np
 import pandas as pd
-
-
-try:
-    from functools import cache  # type: ignore
-except ImportError:
-    from functools import lru_cache
-
-    cache = lru_cache(None)
 
 
 # Don't repeat the most common inputs that occur when there are no state changes, but

--- a/wombat/windfarm/windfarm.py
+++ b/wombat/windfarm/windfarm.py
@@ -1,10 +1,12 @@
 """Creates the Windfarm class/model."""
+
 from __future__ import annotations
 
 import csv
 import datetime as dt
 import itertools
 from math import fsum
+from functools import cache
 
 import numpy as np
 import pandas as pd
@@ -15,7 +17,6 @@ from wombat.core import RepairManager, WombatEnvironment
 from wombat.core.library import load_yaml
 from wombat.windfarm.system import Cable, System
 from wombat.core.data_classes import String, SubString, WindFarmMap, SubstationMap
-from wombat.utilities.utilities import cache
 
 
 class Windfarm:


### PR DESCRIPTION
This PR removes support for the older Python versions' caching methods in favor of `functools.cache`. This also removes the need to import the standardized `cache` from utilities, and directly imports `functools.cache` across WOMBAT.