### PR TITLE
Bug Fix: Address Inconsistenty in Turbine vs. Wind Farm Availability

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,14 +6,14 @@ repos:
     hooks:
         - id: isort
           name: isort
-          stages: [commit]
+          stages: [pre-commit]
 
 - repo: https://github.com/asottile/pyupgrade
   rev: v3.15.2
   hooks:
   - id: pyupgrade
     args: [--py39-plus]
-    stages: [commit]
+    stages: [pre-commit]
 
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   rev: v0.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# CHANGELOG
+
+## Unreleased (TBD)
+
+- Fixes a discrepancy where the wind farm vs turbine availability losses do not match. A slight difference in total availability will be noticeable as a result.
+
 ## 0.9.5 (6 August 2024)
 
 - Fixes a bug that causes delayed mobilizations. The underlying cause was the lack of

--- a/wombat/core/environment.py
+++ b/wombat/core/environment.py
@@ -790,8 +790,7 @@ class WombatEnvironment(simpy.Environment):
         turbines = self.windfarm.turbine_weights[t_id].values * op[t_id]
         total = np.sum(
             [
-                op[[sub]]
-                * np.array(
+                np.array(
                     [
                         [math.fsum(row)]
                         for _, row in turbines[val["turbines"]].iterrows()
@@ -855,6 +854,12 @@ class WombatEnvironment(simpy.Environment):
             .set_index("datetime")
             .sort_values("datetime")
         )
+
+        # Adjust the turbine operational values to account for substation downtime
+        for sub, val in self.windfarm.substation_turbine_map.items():
+            log_df[val["turbines"]] *= log_df[[sub]].values
+
+        # Calculate the wind farm aggregate operational value
         log_df["windfarm"] = self._calculate_windfarm_total(log_df)
         return log_df
 

--- a/wombat/core/post_processor.py
+++ b/wombat/core/post_processor.py
@@ -369,8 +369,6 @@ class Metrics:
         # Determine the operational capacity of each turbine with substation downtime
         operations_cols = ["year", "month", "day", "windfarm"] + self.turbine_id
         turbine_operations = self.operations[operations_cols].copy()
-        for sub, val in self.substation_turbine_map.items():
-            turbine_operations[val["turbines"]] *= self.operations[[sub]].values
 
         hourly = turbine_operations.loc[:, self.turbine_id]
 


### PR DESCRIPTION
This PR fixes a bug where the substation availability was not being consistently counted against the upstream turbine's availability for both the turbine- and wind farm-level aggregation. This will have a modest impact on end availability results.

Kudos to @dmulash for identifying the discrepancy!