### PR TITLE
PATCH: Fix YAML loading bug causing `ResourceWarning`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.9.7 (12 February 2025)
+
+- Fixes a new bug where YAML is now sensitive to the implicit closing of files by using
+  a context manager to open a YAML file and return the contents.
+
 ## 0.9.6 (11 December 2024)
 
 - Fixes a discrepancy where the wind farm vs turbine availability losses do not match. A slight difference in total availability will be noticeable as a result.

--- a/wombat/core/library.py
+++ b/wombat/core/library.py
@@ -20,7 +20,6 @@ signifies the user's input library path:
 
 from __future__ import annotations
 
-import os
 import re
 from typing import Any
 from pathlib import Path
@@ -83,7 +82,10 @@ def load_yaml(path: str | Path, fname: str | Path) -> Any:
     Any
         Whatever content is in the YAML file.
     """
-    return yaml.load(open(os.path.join(path, fname)), Loader=custom_loader)
+    if isinstance(path, str):
+        path = Path(path).resolve()
+    with (path / fname).open() as f:
+        return yaml.load(f, Loader=custom_loader)
 
 
 def create_library_structure(


### PR DESCRIPTION
This PR fixes a bug causing PyYAML to raise a `ResourceWarning` because of unclosed files by using a context manager to open the file and return its contents.