### PR TITLE
PATCH: Fix PyPI publishing workflow

### DIFF
--- a/.github/workflows/python-publish-test.yml
+++ b/.github/workflows/python-publish-test.yml
@@ -34,5 +34,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: True
-          password: ${{ secrets.TEST_PYPI_PASSWORD }}
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -33,4 +33,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: True
-          password: ${{ secrets.PYPI_PASSWORD }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixes a new bug where YAML is now sensitive to the implicit closing of files by using
   a context manager to open a YAML file and return the contents.
+- Removes PyPI secret usage now that trusted publishing fails with redundant permissions.
 
 ## 0.9.6 (11 December 2024)
 


### PR DESCRIPTION
This PR removes the unnecessary secrets passing for a trusted publisher workflow. Due to changes in the GH Action, the redundant permissions now fail, and so it must be removed to publish successfully.