### PR TITLE
PATCH: PyPI publishing permissions

### DIFF
--- a/.github/workflows/python-publish-test.yml
+++ b/.github/workflows/python-publish-test.yml
@@ -11,9 +11,13 @@ on:
 jobs:
   release-test-pypi:
     # Upload to Test PyPI on every pushed tag.
-    environment: release-pypi
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
+    environment:
+      name: release-pypi
+      url: https://test.pypi.org/p/wombat
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,10 +9,14 @@ on:
 
 jobs:
   release-pypi:
-    environment: release-pypi
     # Upload to PyPI on every published release
     if: github.event.action == 'published'
+    environment:
+      name: release-pypi
+      url: https://pypi.org/p/wombat
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds the missing and mandatory permissions configuration for PyPI's trusted publishing.