### PR TITLE
Revert: "Fix: Maintenance Frequency Conversion (#169)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 # CHANGELOG
 
-## 0.9.8
-
-- Fixes a major bug that previously removed the conversion from days to hours for the
-  `Maintenance.frequency` parameter.
-- Temporarily marks two servicing equipment as skipped so that the tests can be refactored
-  to be less reliant on complex timing between servicing equipment.
-
 ## 0.9.7 (12 February 2025)
 
 - Fixes a new bug where YAML is now sensitive to the implicit closing of files by using

--- a/tests/test_service_equipment.py
+++ b/tests/test_service_equipment.py
@@ -1,5 +1,4 @@
 """Test the ServiceEquipment class."""
-
 from __future__ import annotations
 
 import numpy as np
@@ -269,7 +268,6 @@ def test_calculate_equipment_cost(env_setup):
     assert cost == n_hours / 24 * ctv_dict["equipment_rate"]
 
 
-@pytest.mark.skip(reason="The timing of the failures needs to be updated")
 def test_onsite_scheduled_equipment_logic(env_setup_full_profile):
     """Test the simulation logic of a scheduled CTV."""
     env = env_setup_full_profile
@@ -1922,7 +1920,6 @@ def test_scheduled_equipment_logic(env_setup_full_profile):
     assert len(get_items_by_description(manager, "fsv call")) == 0
 
 
-@pytest.mark.skip(reason="The timing of the failures needs to be updated")
 def test_unscheduled_service_equipment_call(env_setup_full_profile):
     """Tests the calling of downtime-based and requests-based service equipment. This
     test will only consider that the equipment is mobilized when required, arrives at

--- a/wombat/__init__.py
+++ b/wombat/__init__.py
@@ -4,4 +4,4 @@ from wombat.core import Metrics, Simulation
 from wombat.core.library import create_library_structure
 
 
-__version__ = "0.9.8"
+__version__ = "0.9.7"

--- a/wombat/windfarm/system/subassembly.py
+++ b/wombat/windfarm/system/subassembly.py
@@ -13,7 +13,6 @@ from wombat.core import (
     SubassemblyData,
     WombatEnvironment,
 )
-from wombat.utilities.time import HOURS_IN_DAY
 
 
 class Subassembly:
@@ -183,7 +182,7 @@ class Subassembly:
             Time between maintenance requests.
         """
         while True:
-            hours_to_next = maintenance.frequency * HOURS_IN_DAY
+            hours_to_next = maintenance.frequency
             if hours_to_next == 0:
                 remainder = self.env.max_run_time - self.env.now
                 try:
@@ -222,7 +221,7 @@ class Subassembly:
 
         Yields
         ------
-        simpy.events.Event
+        simpy.events. HOURS_IN_DAY
             Time between failure events that need to request a repair.
         """
         while True:


### PR DESCRIPTION
This reverts commit 58f500d648660fd7789521ea103beee618dd1124, which erroneously "fixed" a timing issue. The reversion undoes that work which had actually just been moved to a more logical spot in the code.