### PR TITLE
Fix pandas Depreciation warning in plot

### DIFF
--- a/wombat/utilities/plot.py
+++ b/wombat/utilities/plot.py
@@ -309,7 +309,7 @@ def plot_operational_levels(
     env_datetime_df["month"] = env_datetime_df.env_datetime.dt.month
     env_datetime_df["month_year"] = pd.DatetimeIndex(
         env_datetime_df.env_datetime
-    ).to_period("m")
+    ).to_period("M")
     ix = ~env_datetime_df.month_year.duplicated() & (
         env_datetime_df.month.isin((4, 7, 10))
     )


### PR DESCRIPTION
When using DatetimeIndex.to_period('m') pandas throws a FutureWarning and advice to use 'M' instead

pandas.__version == '2.2.2'

![image](https://github.com/user-attachments/assets/90137b3b-10f1-42a3-ba63-3687ff5f3b47)
