### PR TITLE
Feature: Expand Maintenance Frequency Defintions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,45 +4,78 @@
 
 ### Features
 
-- Multiple instances of a servicing equipment can be created with a list of the name
-  and number of them in the following forms. This creates copies where the equipment's
-  name is suffixed with a 1-indexed indication of which number it is, such as
-  "Crew Transfer Vessel -1" through "Crew Transfer Vessel - 4" for the below example.
+#### Date-based maintenance and improved timing
 
-  ```yaml
-  ...
-  servicing_equipment:
-    - - ctv.yaml
-      - 4
-    - [hlv.yaml, 2]
-    - dsv.yaml
-  ...
-  ```
+The frequency of maintenance events is now significantly more customizable by enabling
+custom starting dates and more resolved frequency inputs. There is no change required
+for existing configurations as the default value will `frequency` number of days until
+the next event.
 
-- WOMBAT configurations now allow for the embedding of servicing equipment, turbine,
-  substation, cable, and port data within the main configuration. Now, the only files
-  required outside the primary configuration YAML are the weather profile and layout.
-  To utilize this update, data can be included in the following form:
+- `frequency` is an integer input (0 for unmodeled)
+- `frequency_basis` indicates the time basis for `frequency`, which is modeled in two
+  forms:
+  - timing based: amount of operational time that should pass before an event occurs,
+    which does not count downtime (repairs, upstream failure, or system offline) in the
+    time until the next event.
+    - "days": number of days between events (default)
+    - "months": number of months between events
+    - "years": number of years between events
+  - date based: uses a set schedule for when events should occur, regardless of downtime
+    and will use `start_date` as the first occurrence of the event.
+    - "date-days": number of days between events
+    - "date-months": number of months between events
+    - "date-years": number of years between events
+- `start_date`: The first occurrence of the maintenance event, which defaults to the
+  simulation start date + the expected interval. If the input is prior to the simulation
+  start date, then it is treated as a staggered timing, so, for instance, a biannual
+  event starting the year prior to the simulation ends up being staggered with the first
+  occurrence in the first year of the simulation, not the second. Similarly, this
+  allows for maintenance activities to start well into the simulation period allowing
+  for costs on OEM-warrantied maintenance activities to be unmodeled.
 
-  ```yaml
-  servicing_equipment:
-    - [7, ctv]
-  ...  # Other configuration details
-  vessels:
-    ctv:
-      ...  # Contents of library/corewind/vessels/ctv.yaml
-  turbines:
-    corewind_15MW:
-      ...  # Contents of library/corewind/turbines/corewind_15MW.yaml
-  substations:
-    corewind_substation:
-      ...  # Contents of library/corewind/substations/corewind_substation.yaml
-  cables:
-    corewind_array:
-      ...  # Contents of library/corewind/cables/corewind_array.yaml
-    corewind_export:
-      ...  # Contents of library/corewind/cables/corewind_export.yaml
-  ```
+#### Repeat vessel configuration simplification
+
+Multiple instances of a servicing equipment can be created with a list of the name
+and number of them in the following forms. This creates copies where the equipment's
+name is suffixed with a 1-indexed indication of which number it is, such as
+"Crew Transfer Vessel -1" through "Crew Transfer Vessel - 4" for the below example.
+
+```yaml
+...
+servicing_equipment:
+  - - ctv.yaml
+    - 4
+  - [hlv.yaml, 2]
+  - dsv.yaml
+...
+```
+
+#### Single(ish) file configuration
+
+WOMBAT configurations now allow for the embedding of servicing equipment, turbine,
+substation, cable, and port data within the main configuration. Now, the only files
+required outside the primary configuration YAML are the weather profile and layout.
+To utilize this update, data can be included in the following form:
+
+```yaml
+servicing_equipment:
+  - [7, ctv]
+...  # Other configuration details
+vessels:
+  ctv:
+    ...  # Contents of library/corewind/vessels/ctv.yaml
+turbines:
+  corewind_15MW:
+    ...  # Contents of library/corewind/turbines/corewind_15MW.yaml
+substations:
+  corewind_substation:
+    ...  # Contents of library/corewind/substations/corewind_substation.yaml
+cables:
+  corewind_array:
+    ...  # Contents of library/corewind/cables/corewind_array.yaml
+  corewind_export:
+    ...  # Contents of library/corewind/cables/corewind_export.yaml
+```
 
 ### Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,41 @@ the next event.
   allows for maintenance activities to start well into the simulation period allowing
   for costs on OEM-warrantied maintenance activities to be unmodeled.
 
+A few examples of more complex scenarios assuming a 1/1/2000 simulation starting date:
+
+- Semiannual event to occur starting in the 3rd month of the simulation:
+
+  ```yaml
+  frequency: 6
+  frequency_basis: months
+  start_date: "9/1/1999"
+  ```
+
+- Summer-based annual event with the first occurrence in the 3rd year of the simulation:
+
+  ```yaml
+  frequency: 1
+  frequency_basis: years
+  start_date: "6/1/2003"
+  ```
+
+- Annual, June maintenance activity:
+
+  ```yaml
+  frequency: 1
+  frequency_basis: "date-years"
+  start_date: "6/1/2000"
+  ```
+
+- Biannual, June maintenance activity that should start in the first year, and every
+  other year after that:
+
+  ```yaml
+  frequency: 1
+  frequency_basis: "date-years"
+  start_date: "6/1/2000"
+  ```
+
 #### Repeat vessel configuration simplification
 
 Multiple instances of a servicing equipment can be created with a list of the name

--- a/docs/API/types.md
+++ b/docs/API/types.md
@@ -1,5 +1,5 @@
 (types)=
-# Data Classes
+# Conifgurations (Data Classes)
 
 The WOMBAT architecture relies heavily on a base set of data classes to process most of
 the model's inputs. This enables a rigid, yet robust data model to properly define a
@@ -36,7 +36,8 @@ hoping for the best.
    :members:
    :undoc-members:
    :exclude-members: time, materials, frequency, equipment, system_value, description,
-    level, operation_reduction, rng, service_equipment, replacement
+    level, operation_reduction, rng, service_equipment, replacement, frequency_basis,
+    start_date, request_id, event_dates
 ```
 
 (types:maintenance:unscheduled)=
@@ -48,7 +49,7 @@ hoping for the best.
    :undoc-members:
    :exclude-members: scale, shape, time, materials, operation_reduction, weibull, name,
     maintenance, failures, level, equipment, system_value, description, rng,
-    service_equipment, replacement
+    service_equipment, replacement, request_id
 ```
 
 (types:maintenance:requests)=

--- a/docs/examples/how_to.md
+++ b/docs/examples/how_to.md
@@ -543,6 +543,52 @@ project_capacity: 240
 #                          pointer is provided here and located in: dinwoodie / project / port
 ```
 
+```{note}
+As of v0.10, multiple vessels can be modeled with a single configuration, and vessel,
+turbine, cable, and substation configurations can be included directly in the contents
+of the primary configuration.
+```
+
+Alternatively, the configuration can be simplified to be of the following form to utilize
+repeated vessel configurations and the single file configuration. The new keys for where
+to embed the data directly correspond to the folder names where the files originally
+resided. For instance, below embedding `<library>/vessels/ctv.yaml` into the
+main configuration means that we need a new key called `vessels`, with a subkey
+underneath called `ctv`.
+
+```{code-block} yaml
+name: dinwoodie_base
+weather: alpha_ventus_weather_2002_2014.csv  # located in: dinwoodie / weather
+service_equipment:
+# YAML-encoded list, but could also be created in standard Python list notation with
+# square brackets: [ctv1.yaml, ctv2.yaml, ..., hlv_requests.yaml]
+# All below equipment configurations are located in: dinwoodie / vessels
+  - [ctv, 3]
+  - fsv_requests.yaml
+  - hlv_requests.yaml
+layout: layout.csv  # located in: dinwoodie / windfarm
+inflation_rate: 0
+fixed_costs: fixed_costs.yaml  # located in: dinwoodie / project / config
+workday_start: 7
+workday_end: 19
+start_year: 2003
+end_year: 2012
+project_capacity: 240
+vessels:
+  ctv:
+    ... # contents of ctv1.yaml without the numbered naming which is created automatically
+turbines:
+  ...
+cables:
+  ...
+substations:
+  ...
+```
+
+For a complete example of this, please see the
+`library/corewind/project/config/morro_bay_in_situ_consolidated.yaml` configuration
+file.
+
 ## Create a simulation
 
 There are two ways that this could be done, the first is to use the classmethod
@@ -626,7 +672,6 @@ end = perf_counter()
 timing = end - start
 print(f"Run time: {timing / 60:,.2f} minutes")
 ```
-
 
 ## Metric computation
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -55,7 +55,7 @@ events. The following will break down the differences between each of these syst
 modeling assumptions as well as the basic operations of the maintenance and failure models.
 
 - Maintenance
-  - `frequency`: based on a fixed number of days between an event
+  - `frequency`: based on an amount of time between events and a given starting date.
   - `operation_reduction`: the percentage of degradation the triggering of this event
     cause
 - Failure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "types-typed-ast>=1.5",
     "types-PyYAML>=6",
     "types-python-dateutil>=2.8",
+    "python-dateutil",
 ]
 keywords = [
     "python3",

--- a/tests/test_cable.py
+++ b/tests/test_cable.py
@@ -86,9 +86,7 @@ def test_cable_failures(env_setup):
     # for p in cable.processes.values():
     #     pprint(p._target.__dict__)
     assert getattr(list(cable.processes.values())[0]._target, "_delay", None) is None
-    assert getattr(list(cable.processes.values())[1]._target, "_delay", None) == (
-        1416 - catastrophic_timeout
-    )
+    assert getattr(list(cable.processes.values())[1]._target, "_delay", None) is None
 
     # Check the failure was submitted and no other items exist for this cable
     assert sum(req.system_id == "cable::OSS1::S00T1" for req in manager.items) == 1

--- a/tests/test_cable.py
+++ b/tests/test_cable.py
@@ -86,7 +86,10 @@ def test_cable_failures(env_setup):
     # for p in cable.processes.values():
     #     pprint(p._target.__dict__)
     assert getattr(list(cable.processes.values())[0]._target, "_delay", None) is None
-    assert getattr(list(cable.processes.values())[1]._target, "_delay", None) is None
+    assert (
+        getattr(list(cable.processes.values())[1]._target, "_delay", None)
+        == env.max_run_time - catastrophic_timeout
+    )
 
     # Check the failure was submitted and no other items exist for this cable
     assert sum(req.system_id == "cable::OSS1::S00T1" for req in manager.items) == 1

--- a/tests/test_data_classes.py
+++ b/tests/test_data_classes.py
@@ -308,7 +308,7 @@ def test_Failure():
     assert cls.system_value == 100000
     assert cls.description == "test"
     # TODO: UPDATE THIS BEFORE PR
-    # assert cls.hours_to_next_failure() == 1394.372138301769
+    # assert cls.hours_to_next_event() == 1394.372138301769
 
     # Test that the default values work
     inputs_all = {
@@ -390,7 +390,7 @@ def test_Failure():
         "rng": RNG,
     }
     cls = Failure.from_dict(inputs_all)
-    assert cls.hours_to_next_failure() is None
+    assert cls.hours_to_next_event() is None
 
     # TODO: Write a test for the weibull function
 

--- a/tests/test_data_classes.py
+++ b/tests/test_data_classes.py
@@ -9,6 +9,7 @@ import attr
 import numpy as np
 import pytest
 import numpy.testing as npt
+from dateutil.relativedelta import relativedelta
 
 from wombat.core.library import load_yaml
 from wombat.core.data_classes import (
@@ -215,6 +216,9 @@ def test_FromDictMixin():
 
 def test_Maintenance():
     """Tests the `Maintenance` class."""
+    start = datetime.datetime(2000, 1, 1)
+    end = datetime.datetime(2001, 1, 1)
+    max_run_time = (end - start).days * 24
     # Test for all inputs being provided and converted
     inputs_all = {
         "description": "test",
@@ -226,11 +230,12 @@ def test_Maintenance():
         "system_value": 100000,
     }
     cls = Maintenance.from_dict(inputs_all)
+    cls._update_date_based_timing(start, end, max_run_time)
     assert cls.description == "test"
     assert cls.time == 14.0
     assert cls.materials == 100.0
-    assert cls.frequency == 200.0
-    assert cls.hours_to_next_event(0, 0) == (200.0 * 24, False)
+    assert cls.frequency == relativedelta(days=200)
+    assert cls.hours_to_next_event(start) == (200.0 * 24, False)
     assert cls.service_equipment == ["CTV"]
     assert cls.operation_reduction == 0.5
     assert cls.system_value == 100000.0
@@ -244,12 +249,13 @@ def test_Maintenance():
         "system_value": 100000,
     }
     cls = Maintenance.from_dict(inputs_defaults)
+    cls._update_date_based_timing(start, end, max_run_time)
     class_data = attr.fields_dict(Maintenance)
     assert cls.description == class_data["description"].default
     assert cls.time == 14.0
     assert cls.materials == 100.0
-    assert cls.frequency == 200.0
-    assert cls.hours_to_next_event(0, 0) == (200.0 * 24, False)
+    assert cls.frequency == relativedelta(days=200)
+    assert cls.hours_to_next_event(start) == (200.0 * 24, False)
     assert cls.service_equipment == ["CTV"]
     assert cls.operation_reduction == class_data["operation_reduction"].default
     assert cls.system_value == 100000.0
@@ -265,11 +271,12 @@ def test_Maintenance():
         "system_value": 100000,
     }
     cls = Maintenance.from_dict(inputs_system_value)
+    cls._update_date_based_timing(start, end, max_run_time)
     assert cls.description == "test"
     assert cls.time == 14.0
     assert cls.materials == 25000.0
-    assert cls.frequency == 200.0
-    assert cls.hours_to_next_event(0, 0) == (200.0 * 24, False)
+    assert cls.frequency == relativedelta(days=200)
+    assert cls.hours_to_next_event(start) == (200.0 * 24, False)
     assert cls.service_equipment == ["CTV", "DSV"]
     assert cls.operation_reduction == 0.5
     assert cls.system_value == 100000.0

--- a/tests/test_data_classes.py
+++ b/tests/test_data_classes.py
@@ -230,7 +230,7 @@ def test_Maintenance():
     assert cls.time == 14.0
     assert cls.materials == 100.0
     assert cls.frequency == 200.0
-    assert cls.hours_to_next_event() == 200.0 * 24
+    assert cls.hours_to_next_event(0, 0) == (200.0 * 24, False)
     assert cls.service_equipment == ["CTV"]
     assert cls.operation_reduction == 0.5
     assert cls.system_value == 100000.0
@@ -249,7 +249,7 @@ def test_Maintenance():
     assert cls.time == 14.0
     assert cls.materials == 100.0
     assert cls.frequency == 200.0
-    assert cls.hours_to_next_event() == 200.0 * 24
+    assert cls.hours_to_next_event(0, 0) == (200.0 * 24, False)
     assert cls.service_equipment == ["CTV"]
     assert cls.operation_reduction == class_data["operation_reduction"].default
     assert cls.system_value == 100000.0
@@ -269,7 +269,7 @@ def test_Maintenance():
     assert cls.time == 14.0
     assert cls.materials == 25000.0
     assert cls.frequency == 200.0
-    assert cls.hours_to_next_event() == 200.0 * 24
+    assert cls.hours_to_next_event(0, 0) == (200.0 * 24, False)
     assert cls.service_equipment == ["CTV", "DSV"]
     assert cls.operation_reduction == 0.5
     assert cls.system_value == 100000.0
@@ -311,7 +311,7 @@ def test_Failure():
     assert cls.system_value == 100000
     assert cls.description == "test"
     # TODO: UPDATE THIS BEFORE PR
-    # assert cls.hours_to_next_event() == 1394.372138301769
+    # assert cls.hours_to_next_event(0, 0) == 1394.372138301769, False
 
     # Test that the default values work
     inputs_all = {

--- a/tests/test_data_classes.py
+++ b/tests/test_data_classes.py
@@ -229,7 +229,8 @@ def test_Maintenance():
     assert cls.description == "test"
     assert cls.time == 14.0
     assert cls.materials == 100.0
-    assert cls.frequency == 200.0 * 24
+    assert cls.frequency == 200.0
+    assert cls.hours_to_next_event() == 200.0 * 24
     assert cls.service_equipment == ["CTV"]
     assert cls.operation_reduction == 0.5
     assert cls.system_value == 100000.0
@@ -247,7 +248,8 @@ def test_Maintenance():
     assert cls.description == class_data["description"].default
     assert cls.time == 14.0
     assert cls.materials == 100.0
-    assert cls.frequency == 200.0 * 24
+    assert cls.frequency == 200.0
+    assert cls.hours_to_next_event() == 200.0 * 24
     assert cls.service_equipment == ["CTV"]
     assert cls.operation_reduction == class_data["operation_reduction"].default
     assert cls.system_value == 100000.0
@@ -266,7 +268,8 @@ def test_Maintenance():
     assert cls.description == "test"
     assert cls.time == 14.0
     assert cls.materials == 25000.0
-    assert cls.frequency == 200.0 * 24
+    assert cls.frequency == 200.0
+    assert cls.hours_to_next_event() == 200.0 * 24
     assert cls.service_equipment == ["CTV", "DSV"]
     assert cls.operation_reduction == 0.5
     assert cls.system_value == 100000.0

--- a/tests/test_data_classes.py
+++ b/tests/test_data_classes.py
@@ -229,7 +229,7 @@ def test_Maintenance_conversion():
         "system_value": 100000,
     }
     cls = Maintenance.from_dict(inputs_all)
-    cls._update_date_based_timing(start, end, max_run_time)
+    cls._update_event_timing(start, end, max_run_time)
     assert cls.description == "test"
     assert cls.time == 14.0
     assert cls.materials == 100.0
@@ -259,38 +259,38 @@ def test_Maintenance_frequency():
         "system_value": 100000,
     }
     cls = Maintenance.from_dict(inputs_all)
-    cls._update_date_based_timing(start, end, max_run_time)
+    cls._update_event_timing(start, end, max_run_time)
     assert cls.frequency == relativedelta(days=(end - start).days)
-    assert cls.frequency_basis == "days"
+    assert cls.frequency_basis == "date-hours"
 
     # Test the conversion for standard, non-date inputs
     start = datetime.datetime(2000, 2, 1)
     end = datetime.datetime(2001, 1, 1)
     max_run_time = (end - start).days * 24
 
-    inputs_all["frequency"] = 3 / 1
-    inputs_all["frequency_basis"] = "date-monthly"
+    inputs_all["frequency"] = 3
+    inputs_all["frequency_basis"] = "months"
     cls = Maintenance.from_dict(inputs_all)
-    cls._update_date_based_timing(start, end, max_run_time)
+    cls._update_event_timing(start, end, max_run_time)
     assert cls.frequency == relativedelta(months=3)
 
     inputs_all["frequency"] = 4
     inputs_all["frequency_basis"] = "years"
     cls = Maintenance.from_dict(inputs_all)
-    cls._update_date_based_timing(start, end, max_run_time)
+    cls._update_event_timing(start, end, max_run_time)
     assert cls.frequency == relativedelta(years=4)
 
     # Test the conversion for date-based inputs
     inputs_all["frequency"] = 3
-    inputs_all["frequency_basis"] = "months"
+    inputs_all["frequency_basis"] = "date-months"
     cls = Maintenance.from_dict(inputs_all)
-    cls._update_date_based_timing(start, end, max_run_time)
+    cls._update_event_timing(start, end, max_run_time)
     assert cls.frequency == relativedelta(months=3)
 
     inputs_all["frequency"] = 4
-    inputs_all["frequency_basis"] = "years"
+    inputs_all["frequency_basis"] = "date-years"
     cls = Maintenance.from_dict(inputs_all)
-    cls._update_date_based_timing(start, end, max_run_time)
+    cls._update_event_timing(start, end, max_run_time)
     assert cls.frequency == relativedelta(years=4)
 
 
@@ -307,7 +307,7 @@ def test_Maintenance_defaults():
         "system_value": 100000,
     }
     cls = Maintenance.from_dict(inputs_defaults)
-    cls._update_date_based_timing(start, end, max_run_time)
+    cls._update_event_timing(start, end, max_run_time)
     class_data = attr.fields_dict(Maintenance)
     assert cls.description == class_data["description"].default
     assert cls.time == 14.0
@@ -337,7 +337,7 @@ def test_Maintenance_proportional_materials():
         "system_value": 100000,
     }
     cls = Maintenance.from_dict(inputs_system_value)
-    cls._update_date_based_timing(start, end, max_run_time)
+    cls._update_event_timing(start, end, max_run_time)
     assert cls.description == "test"
     assert cls.time == 14.0
     assert cls.materials == 25000.0
@@ -363,7 +363,7 @@ def test_Maintenance_assign_id():
         "system_value": 100000,
     }
     cls = Maintenance.from_dict(inputs_system_value)
-    cls._update_date_based_timing(start, end, max_run_time)
+    cls._update_event_timing(start, end, max_run_time)
     correct_id = "M00001"
     cls.assign_id(request_id=correct_id)
     assert cls.request_id == correct_id

--- a/wombat/core/data_classes.py
+++ b/wombat/core/data_classes.py
@@ -464,6 +464,7 @@ class Maintenance(FromDictMixin):
             (
                 "days",
                 "years",
+                "months",
                 "date-annual",
                 "date-semiannual",
                 "date-quarterly",

--- a/wombat/core/data_classes.py
+++ b/wombat/core/data_classes.py
@@ -519,12 +519,19 @@ class Maintenance(FromDictMixin):
         ValueError
             Raised if an invalid ``Maintenance.frequency_basis`` is used.
         """
+        # For events that should not occur, overwrite the user-passed timing settings
+        # to ensure there is a single event scheduled for just after the simulation end
         n_frequency = deepcopy(self.frequency)
         if self.frequency == 0:
+            basis = "days"
+            n_frequency = 1
             diff = relativedelta(hours=max_run_time)
+            object.__setattr__(self, "frequency_basis", "date-hours")
+            object.__setattr__(self, "start_date", start)
+        else:
+            basis = self.frequency_basis.replace("date-", "")
+            diff = relativedelta(**{basis: self.frequency})  # type: ignore
 
-        basis = self.frequency_basis.replace("date-", "")
-        diff = relativedelta(**{basis: self.frequency})  # type: ignore
         years = end.year - min(self.start_date.year, start.year) + 1
 
         if TYPE_CHECKING:

--- a/wombat/core/data_classes.py
+++ b/wombat/core/data_classes.py
@@ -438,7 +438,7 @@ class Maintenance(FromDictMixin):
             Returns ``None`` for a non-modelled failure, or the time until the next
             simulated failure.
         """
-        if self.frequency is None:
+        if self.frequency == 0:
             return None
 
         return self.frequency * HOURS_IN_DAY

--- a/wombat/core/data_classes.py
+++ b/wombat/core/data_classes.py
@@ -407,7 +407,8 @@ class Maintenance(FromDictMixin):
     materials : float
         Cost of materials required to perform maintenance, in USD.
     frequency : int | str
-        Optimal number of days between performing maintenance, in days.
+        Number of days, months, or years between events, see :py:attr:`frequency_basis`
+        for further configuration. Defaults to days as the basis.
     service_equipment: list[str] | str
         Any combination of th following ``Equipment.capability`` options.
 
@@ -434,6 +435,36 @@ class Maintenance(FromDictMixin):
 
     level : int, optional
         Severity level of the maintenance. Defaults to 0.
+    frequency_basis : str, optional
+        The basis of the frequency input. Defaults to "days". Must be one of the
+        following inputs:
+
+        - days: :py:attr:`frequency` corresponds to the number of days between events.
+        - months: :py:attr:`frequency` corresponds to the number of months between
+        events.
+
+        - years: :py:attr:`frequency` corresponds to the number of years between events.
+        - date-days: :py:attr:`frequency` corresponds to the exact number of days
+        between events, starting with :py:attr:`start_date` (i.e. downtime does not
+        impact timing).
+
+        - date-months: :py:attr:`frequency` corresponds to the number of months between
+        events, starting with :py:attr:`start_date` (i.e. downtime does not impact
+        timing).
+
+        - date-years: :py:attr:`frequency` corresponds to the number of years between
+        events, starting with :py:attr:`start_date` (i.e. downtime does not impact
+        timing).
+
+    start_date : str, optional
+        The date in "MM/DD/YYYY" or similarly legible format
+        (``pandas.to_datetime(start_date)`` used to convert internally) of the first
+        instance of the maintenance event. For instance, this allows for annual summer
+        maintenance activities for reduced downtime of fleet-wide preventative
+        maintenance, or for allowing a delayed start to certain activities (nothing
+        in the first five years, then run on a regular schedule). Defaults to the
+        frequency + simulation start date and is used for any
+        :py:attr:`frequency_basis`.
     """
 
     time: float = field(converter=float)

--- a/wombat/core/data_classes.py
+++ b/wombat/core/data_classes.py
@@ -298,23 +298,6 @@ def validate_0_1_inclusive(
         )
 
 
-def one_of(items: Sequence) -> Callable:
-    """Validates that the user input is one of :py:attr:`items`.
-
-    Parameters
-    ----------
-    items : Sequence
-        A list-like of valid values.
-    """
-
-    def validator(cls, attribute: attrs.Attribute, value: Any) -> None:
-        """Validator method that is returned to attrs."""
-        if value not in items:
-            raise ValueError(f"`{attribute.name}` must be one of: {','.join(items)}")
-
-    return validator
-
-
 def to_datetime(value: str | datetime.datetime) -> datetime.datetime:
     """Converts a date string to a Python ``datetime`` object.
 
@@ -482,7 +465,7 @@ class Maintenance(FromDictMixin):
     frequency_basis: str = field(
         default="days",
         converter=(str.strip, str.lower),
-        validator=one_of(
+        validator=attrs.validators.in_(
             (
                 "days",
                 "months",

--- a/wombat/core/data_classes.py
+++ b/wombat/core/data_classes.py
@@ -411,7 +411,6 @@ class Maintenance(FromDictMixin):
         """Convert frequency to hours (simulation time scale) and the equipment
         requirement to a list.
         """
-        object.__setattr__(self, "frequency", self.frequency * HOURS_IN_DAY)
         object.__setattr__(
             self,
             "materials",
@@ -427,6 +426,22 @@ class Maintenance(FromDictMixin):
             The ``wombat.core.RepairManager`` generated identifier.
         """
         object.__setattr__(self, "request_id", request_id)
+
+    def hours_to_next_event(self) -> float | None:
+        """Sample the next time to failure in a Weibull distribution. If the ``scale``
+        and ``shape`` parameters are set to 0, then the model will return ``None`` to
+        cause the subassembly to timeout to the end of the simulation.
+
+        Returns
+        -------
+        float | None
+            Returns ``None`` for a non-modelled failure, or the time until the next
+            simulated failure.
+        """
+        if self.frequency is None:
+            return None
+
+        return self.frequency * HOURS_IN_DAY
 
 
 @define(frozen=True, auto_attribs=True)
@@ -519,7 +534,7 @@ class Failure(FromDictMixin):
             convert_ratio_to_absolute(self.materials, self.system_value),
         )
 
-    def hours_to_next_failure(self) -> float | None:
+    def hours_to_next_event(self) -> float | None:
         """Sample the next time to failure in a Weibull distribution. If the ``scale``
         and ``shape`` parameters are set to 0, then the model will return ``None`` to
         cause the subassembly to timeout to the end of the simulation.

--- a/wombat/windfarm/system/cable.py
+++ b/wombat/windfarm/system/cable.py
@@ -342,8 +342,8 @@ class Cable:
             Time between maintenance requests.
         """
         while True:
-            hours_to_next = maintenance.frequency
-            if hours_to_next == 0:
+            hours_to_next = maintenance.hours_to_next_event()
+            if hours_to_next is None:
                 remainder = self.env.max_run_time - self.env.now
                 try:
                     yield self.env.timeout(remainder)
@@ -380,7 +380,7 @@ class Cable:
             Time between failure events that need to request a repair.
         """
         while True:
-            hours_to_next = failure.hours_to_next_failure()
+            hours_to_next = failure.hours_to_next_event()
             if hours_to_next is None:
                 remainder = self.env.max_run_time - self.env.now
                 try:

--- a/wombat/windfarm/system/cable.py
+++ b/wombat/windfarm/system/cable.py
@@ -162,7 +162,7 @@ class Cable:
 
         for i, maintenance in enumerate(self.data.maintenance):
             maintenance._update_date_based_timing(
-                self.env.start_datetime, self.env.end_datetime
+                self.env.start_datetime, self.env.end_datetime, self.env.max_run_time
             )
             desc = maintenance.description
             yield desc, self.env.process(self.run_single_maintenance(maintenance))
@@ -344,59 +344,29 @@ class Cable:
         simpy.events.Timeout
             Time between maintenance requests.
         """
-        # while True:
-        #     hours_to_next = maintenance.hours_to_next_event()
-        #     if hours_to_next is None:
-        #         remainder = self.env.max_run_time - self.env.now
-        #         try:
-        #             yield self.env.timeout(remainder)
-        #         except simpy.Interrupt:
-        #             remainder -= self.env.now
-        #     else:
-        #         while hours_to_next > 0:
-        #             start = -1  # Ensure an interruption before processing is caught
-        #             try:
-        #                 # If the replacement has not been completed, then wait
-        #                 yield self.servicing & self.downstream_failure & self.broken
-
-        #                 start = self.env.now
-        #                 yield self.env.timeout(hours_to_next)
-        #                 hours_to_next = 0
-        #                 self.trigger_request(maintenance)
-        #             except simpy.Interrupt as i:
-        #                 if i.cause == "replacement":
-        #                     return
-        #                 hours_to_next -= 0 if start == -1 else self.env.now - start
         while True:
             hours_to_next, accrue_downtime = maintenance.hours_to_next_event(
                 self.env.simulation_time
             )
-            if hours_to_next is None:
-                remainder = self.env.max_run_time - self.env.now
+            while hours_to_next > 0:
+                start = -1  # Ensure an interruption before processing is caught
                 try:
-                    yield self.env.timeout(remainder)
-                except simpy.Interrupt:
-                    remainder -= self.env.now
-            else:
-                while hours_to_next > 0:
-                    start = -1  # Ensure an interruption before processing is caught
-                    try:
-                        # Downtime doesn't accrue for date-based maintenance
-                        if not accrue_downtime:
-                            yield (
-                                self.system.servicing
-                                & self.downstream_failure
-                                & self.broken
-                            )
-                        start = self.env.now
-                        yield self.env.timeout(hours_to_next)
-                        hours_to_next = 0
-                        self.trigger_request(maintenance)
+                    # Downtime doesn't accrue for date-based maintenance
+                    if not accrue_downtime:
+                        yield (
+                            self.system.servicing
+                            & self.downstream_failure
+                            & self.broken
+                        )
+                    start = self.env.now
+                    yield self.env.timeout(hours_to_next)
+                    hours_to_next = 0
+                    self.trigger_request(maintenance)
 
-                    except simpy.Interrupt as i:
-                        if i.cause == "replacement":
-                            return
-                        hours_to_next -= 0 if start == -1 else self.env.now - start
+                except simpy.Interrupt as i:
+                    if i.cause == "replacement":
+                        return
+                    hours_to_next -= 0 if start == -1 else self.env.now - start
 
     def run_single_failure(self, failure: Failure) -> Generator:
         """Runs a process to trigger one type of failure repair request throughout the

--- a/wombat/windfarm/system/cable.py
+++ b/wombat/windfarm/system/cable.py
@@ -161,6 +161,9 @@ class Cable:
             yield desc, self.env.process(self.run_single_failure(failure))
 
         for i, maintenance in enumerate(self.data.maintenance):
+            maintenance._update_date_based_timing(
+                self.env.start_datetime, self.env.end_datetime
+            )
             desc = maintenance.description
             yield desc, self.env.process(self.run_single_maintenance(maintenance))
 
@@ -366,7 +369,7 @@ class Cable:
         #                 hours_to_next -= 0 if start == -1 else self.env.now - start
         while True:
             hours_to_next, accrue_downtime = maintenance.hours_to_next_event(
-                self.env.now, self.env.simulation_time
+                self.env.simulation_time
             )
             if hours_to_next is None:
                 remainder = self.env.max_run_time - self.env.now

--- a/wombat/windfarm/system/cable.py
+++ b/wombat/windfarm/system/cable.py
@@ -161,7 +161,7 @@ class Cable:
             yield desc, self.env.process(self.run_single_failure(failure))
 
         for i, maintenance in enumerate(self.data.maintenance):
-            maintenance._update_date_based_timing(
+            maintenance._update_event_timing(
                 self.env.start_datetime, self.env.end_datetime, self.env.max_run_time
             )
             desc = maintenance.description

--- a/wombat/windfarm/system/subassembly.py
+++ b/wombat/windfarm/system/subassembly.py
@@ -188,7 +188,7 @@ class Subassembly:
         """
         while True:
             hours_to_next, accrue_downtime = maintenance.hours_to_next_event(
-                self.env.now, self.env.simulation_time
+                self.env.simulation_time
             )
             if hours_to_next is None:
                 remainder = self.env.max_run_time - self.env.now

--- a/wombat/windfarm/system/subassembly.py
+++ b/wombat/windfarm/system/subassembly.py
@@ -69,7 +69,7 @@ class Subassembly:
         """
         for maintenance in self.data.maintenance:
             maintenance._update_date_based_timing(
-                self.env.start_datetime, self.env.end_datetime
+                self.env.start_datetime, self.env.end_datetime, self.env.max_run_time
             )
 
         for failure in self.data.failures:

--- a/wombat/windfarm/system/subassembly.py
+++ b/wombat/windfarm/system/subassembly.py
@@ -182,8 +182,8 @@ class Subassembly:
             Time between maintenance requests.
         """
         while True:
-            hours_to_next = maintenance.frequency
-            if hours_to_next == 0:
+            hours_to_next = maintenance.hours_to_next_event()
+            if hours_to_next is None:
                 remainder = self.env.max_run_time - self.env.now
                 try:
                     yield self.env.timeout(remainder)
@@ -225,7 +225,7 @@ class Subassembly:
             Time between failure events that need to request a repair.
         """
         while True:
-            hours_to_next = failure.hours_to_next_failure()
+            hours_to_next = failure.hours_to_next_event()
             if hours_to_next is None:
                 remainder = self.env.max_run_time - self.env.now
                 try:

--- a/wombat/windfarm/system/subassembly.py
+++ b/wombat/windfarm/system/subassembly.py
@@ -68,7 +68,7 @@ class Subassembly:
             subassembly.
         """
         for maintenance in self.data.maintenance:
-            maintenance._update_date_based_timing(
+            maintenance._update_event_timing(
                 self.env.start_datetime, self.env.end_datetime, self.env.max_run_time
             )
 

--- a/wombat/windfarm/system/subassembly.py
+++ b/wombat/windfarm/system/subassembly.py
@@ -67,6 +67,11 @@ class Subassembly:
             Creates a dictionary to keep track of the running processes within the
             subassembly.
         """
+        for maintenance in self.data.maintenance:
+            maintenance._update_date_based_timing(
+                self.env.start_datetime, self.env.end_datetime
+            )
+
         for failure in self.data.failures:
             level = failure.level
             desc = failure.description


### PR DESCRIPTION
This PR enables two modes of frequency bases: date-based, fixed interval frequency and relative frequency to ensure that strict maintenance schedules can be modeled. In addition, this PR also adds in support for starting dates, which can be used in either mode. For a complete sketch of the functionality, please see either the comments in #66 or the [CHANGELOG.md](https://github.com/WISDEM/WOMBAT/blob/feature/date-based-maintenance/CHANGELOG.md).

The documentation and testing have also been updated to ensure that the functionality works as expected.

Closes #66 