### PR TITLE
Enhancment: Use list data for failure classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,10 @@
 - The wind farm operation level calculation was moved to `wombat/utilities/utilities.py`
   so it can be reused when `Metrics` loads the operational data.
 - Update the `Failure` definition to use lists of failure configurations, not
-  dictionaries. Provides a conversion tool in `wombat/core/library.py::convert_failure`.
+  dictionaries. Users can use the following function to update their cable, turbine,
+  substation, and consolidated configurations:
+  `wombat/core/library.py::convert_failure_data` Documentation is available at
+  https://wisdem.github.io/WOMBAT/API/utilities.html#importing-and-converting-from-old-versions.
 
 ## 0.9.7 (12 February 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@
 - Basic tests added for the Simulation API
 - The wind farm operation level calculation was moved to `wombat/utilities/utilities.py`
   so it can be reused when `Metrics` loads the operational data.
+- Update the `Failure` definition to use lists of failure configurations, not
+  dictionaries. Provides a conversion tool in `wombat/core/library.py::convert_failure`.
 
 ## 0.9.7 (12 February 2025)
 

--- a/docs/API/utilities.md
+++ b/docs/API/utilities.md
@@ -1,5 +1,16 @@
 # Helpers and Plotting
 
+(converting-and-structuring)=
+## Importing and Converting From Old Versions
+
+```{eval-rst}
+.. autofunction:: wombat.core.library.load_yaml
+
+.. autofunction:: wombat.core.library.create_library_structure
+
+.. autofunction:: wombat.core.library.convert_failure_data
+```
+
 (plotting)=
 ## Plotting
 

--- a/docs/examples/how_to.md
+++ b/docs/examples/how_to.md
@@ -339,6 +339,13 @@ defintions require a dictionary-style input with keys to match the severity leve
 given failure. For more details on the complete subassembly definition, please visit the
 [Subassembly API documentation](types:windfarm:subassembly).
 
+```{important}
+As of v0.10, failure configurations (`failures`) require a list-based definition. To
+convert older cable, subastation, and turbine configuration failues, use the
+library function `convert_failure_data` as shown in the
+[helpers API documentation](importing-and-converting-from-old-versions).
+```
+
 ```{code-block} yaml
 generator:
   name: generator  # doesn't need to match the subassembly key that becomes System.id
@@ -350,7 +357,7 @@ generator:
     frequency: 365
     operation_reduction: 0  # default value
   failures:
-    1:
+    -
       scale: 0.1333
       shape: 1
       time: 3
@@ -392,7 +399,7 @@ transformer:
       service_equipment: CTV
       frequency: 0
   failures:
-    1:
+    -
       scale: 0
       shape: 0
       time: 0
@@ -466,7 +473,7 @@ maintenance:
     service_equipment: CTV
     frequency: 0
 failures:
-  1:
+  -
     scale: 0
     shape: 0
     time: 0

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,14 +45,20 @@ rob.hammond@nrel.gov.
 
 ## Latest Changes?
 
-As of v0.8, a series of bug fixes in the cable, subassembly, repair management, and
-servicing equipment models that ensure repairs can't happen twice under limited
-circumstances or that more than one repair can occur simultaneously. New features include
-an emissions metric and random seeding of simulations, with significant simulation
-speedups across the board due to using Polars for managing the weather and datetime
-functionality.
+As of v0.10, a series of convenience features and consistency updates have been made.
+- A breaking change to failure data has been made by using lists instead of dictionaries
+  in the configuration of cables, turbines, and substations. To ease adoption, a
+  function has been provided to convert to the new format:
+  https://wisdem.github.io/WOMBAT/API/utilities.html#importing-and-converting-from-old-versions.
+- Single configuration files are now supported for all non-CSV data. This means that
+  servicing equipment, cables, turbines, and substations can all be included in the
+  primary configuration file.
+- Simplification of duplicated servicing equipment definitions: simply provide a list
+  of the filename/id and the number of them that should be in the simulation.
+- Date-based maintenance scheduling is now possible.
 
-Please see the CHANGELOG for details!
+Please see the CHANGELOG for complete information, and the appropriate documentation
+pages
 
 * On this site: https://wisdem.github.io/WOMBAT/changelog.html
 * On GitHub: https://github.com/WISDEM/WOMBAT/blob/main/CHANGELOG.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ As of v0.10, a series of convenience features and consistency updates have been 
 - Date-based maintenance scheduling is now possible.
 
 Please see the CHANGELOG for complete information, and the appropriate documentation
-pages
+pages.
 
 * On this site: https://wisdem.github.io/WOMBAT/changelog.html
 * On GitHub: https://github.com/WISDEM/WOMBAT/blob/main/CHANGELOG.md

--- a/library/code_comparison/dinwoodie/cables/array.yaml
+++ b/library/code_comparison/dinwoodie/cables/array.yaml
@@ -1,18 +1,16 @@
 name: array cable
 maintenance:
-  -
-    description: n/a
-    time: 0
-    materials: 0
-    service_equipment: CTV
-    frequency: 0
+- description: n/a
+  time: 0
+  materials: 0
+  service_equipment: CTV
+  frequency: 0
 failures:
-  1:
-    scale: 0
-    shape: 0
-    time: 0
-    materials: 0
-    operation_reduction: 0
-    service_equipment: CAB
-    level: 1
-    description: n/a
+- scale: 0
+  shape: 0
+  time: 0
+  materials: 0
+  operation_reduction: 0
+  service_equipment: CAB
+  level: 1
+  description: n/a

--- a/library/code_comparison/dinwoodie/cables/export.yaml
+++ b/library/code_comparison/dinwoodie/cables/export.yaml
@@ -1,18 +1,16 @@
 name: export cable
 maintenance:
-  -
-    description: n/a
-    time: 0
-    materials: 0
-    service_equipment: CTV
-    frequency: 0
+- description: n/a
+  time: 0
+  materials: 0
+  service_equipment: CTV
+  frequency: 0
 failures:
-  1:
-    scale: 0
-    shape: 0
-    time: 0
-    materials: 0
-    operation_reduction: 0
-    service_equipment: CAB
-    level: 1
-    description: "none"
+- scale: 0
+  shape: 0
+  time: 0
+  materials: 0
+  operation_reduction: 0
+  service_equipment: CAB
+  level: 1
+  description: none

--- a/library/code_comparison/dinwoodie/substations/offshore_substation.yaml
+++ b/library/code_comparison/dinwoodie/substations/offshore_substation.yaml
@@ -3,19 +3,18 @@ capex_kw: 0
 transformer:
   name: substation
   maintenance:
-    -
-      description: n/a
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      frequency: 0
+  - description: n/a
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: [CTV]
-      operation_reduction: 0
-      level: 1
-      description: n/a
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment:
+    - CTV
+    operation_reduction: 0
+    level: 1
+    description: n/a

--- a/library/code_comparison/dinwoodie/turbines/vestas_v90.yaml
+++ b/library/code_comparison/dinwoodie/turbines/vestas_v90.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
   bin_width: 0.5
@@ -12,49 +12,44 @@ turbine:
     service_equipment: CTV
     frequency: 365
   failures:
-    1:
-      scale: 0.1333
-      shape: 1
-      time: 3
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0.3333
-      shape: 1
-      time: 7.5
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 3.6363
-      shape: 1
-      time: 22
-      materials: 18500
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 25
-      shape: 1
-      time: 26
-      materials: 73500
-      service_equipment: SCN
-      operation_reduction: 0.0
-      level: 4
-      description: major repair
-    5:
-      scale: 12.5
-      shape: 1
-      time: 52
-      materials: 334500
-      service_equipment: LCN
-      operation_reduction: 0.0
-      replacement: true
-      level: 5
-      description: major replacement
+  - scale: 0.1333
+    shape: 1
+    time: 3
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 1
+    description: manual reset
+  - scale: 0.3333
+    shape: 1
+    time: 7.5
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 2
+    description: minor repair
+  - scale: 3.6363
+    shape: 1
+    time: 22
+    materials: 18500
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 3
+    description: medium repair
+  - scale: 25
+    shape: 1
+    time: 26
+    materials: 73500
+    service_equipment: SCN
+    operation_reduction: 0.0
+    level: 4
+    description: major repair
+  - scale: 12.5
+    shape: 1
+    time: 52
+    materials: 334500
+    service_equipment: LCN
+    operation_reduction: 0.0
+    replacement: true
+    level: 5
+    description: major replacement

--- a/library/code_comparison/dinwoodie/turbines/vestas_v90_100pct_reduction.yaml
+++ b/library/code_comparison/dinwoodie/turbines/vestas_v90_100pct_reduction.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
 turbine:
@@ -11,49 +11,44 @@ turbine:
     service_equipment: CTV
     frequency: 365
   failures:
-    1:
-      scale: 0.1333
-      shape: 1
-      time: 3
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0.3333
-      shape: 1
-      time: 7.5
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 3.6363
-      shape: 1
-      time: 22
-      materials: 18500
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 25
-      shape: 1
-      time: 26
-      materials: 73500
-      service_equipment: SCN
-      operation_reduction: 1.0
-      level: 4
-      description: major repair
-    5:
-      scale: 12.5
-      shape: 1
-      time: 52
-      materials: 334500
-      service_equipment: LCN
-      operation_reduction: 1.0
-      replacement: true
-      level: 5
-      description: major replacement
+  - scale: 0.1333
+    shape: 1
+    time: 3
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 1
+    description: manual reset
+  - scale: 0.3333
+    shape: 1
+    time: 7.5
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 2
+    description: minor repair
+  - scale: 3.6363
+    shape: 1
+    time: 22
+    materials: 18500
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 3
+    description: medium repair
+  - scale: 25
+    shape: 1
+    time: 26
+    materials: 73500
+    service_equipment: SCN
+    operation_reduction: 1.0
+    level: 4
+    description: major repair
+  - scale: 12.5
+    shape: 1
+    time: 52
+    materials: 334500
+    service_equipment: LCN
+    operation_reduction: 1.0
+    replacement: true
+    level: 5
+    description: major replacement

--- a/library/code_comparison/dinwoodie/turbines/vestas_v90_annual_service_only.yaml
+++ b/library/code_comparison/dinwoodie/turbines/vestas_v90_annual_service_only.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
   bin_width: 0.5
@@ -12,49 +12,44 @@ turbine:
     service_equipment: CTV
     frequency: 365
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: SCN
-      operation_reduction: 0.0
-      level: 4
-      description: major repair
-    5:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: LCN
-      operation_reduction: 0.0
-      replacement: true
-      level: 5
-      description: major replacement
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 1
+    description: manual reset
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 2
+    description: minor repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 3
+    description: medium repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: SCN
+    operation_reduction: 0.0
+    level: 4
+    description: major repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: LCN
+    operation_reduction: 0.0
+    replacement: true
+    level: 5
+    description: major replacement

--- a/library/code_comparison/dinwoodie/turbines/vestas_v90_annual_service_only_100pct_reduction.yaml
+++ b/library/code_comparison/dinwoodie/turbines/vestas_v90_annual_service_only_100pct_reduction.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
   bin_width: 0.5
@@ -12,49 +12,44 @@ turbine:
     service_equipment: CTV
     frequency: 365
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: SCN
-      operation_reduction: 1.0
-      level: 4
-      description: major repair
-    5:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: LCN
-      operation_reduction: 1.0
-      replacement: true
-      level: 5
-      description: major replacement
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 1
+    description: manual reset
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 2
+    description: minor repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 3
+    description: medium repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: SCN
+    operation_reduction: 1.0
+    level: 4
+    description: major repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: LCN
+    operation_reduction: 1.0
+    replacement: true
+    level: 5
+    description: major replacement

--- a/library/code_comparison/dinwoodie/turbines/vestas_v90_delete.yaml
+++ b/library/code_comparison/dinwoodie/turbines/vestas_v90_delete.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
   bin_width: 0.5
@@ -12,13 +12,12 @@ turbine:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      replacement: true
-      level: 1
-      description: manual reset
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    replacement: true
+    level: 1
+    description: manual reset

--- a/library/code_comparison/dinwoodie/turbines/vestas_v90_failure_200.yaml
+++ b/library/code_comparison/dinwoodie/turbines/vestas_v90_failure_200.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
   bin_width: 0.5
@@ -12,49 +12,44 @@ turbine:
     service_equipment: CTV
     frequency: 365
   failures:
-    1:
-      scale: 0.0667
-      shape: 1
-      time: 3
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0.1667
-      shape: 1
-      time: 7.5
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 1.8182
-      shape: 1
-      time: 22
-      materials: 18500
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 12.5
-      shape: 1
-      time: 26
-      materials: 73500
-      service_equipment: SCN
-      operation_reduction: 0.0
-      level: 4
-      description: major repair
-    5:
-      scale: 6.25
-      shape: 1
-      time: 52
-      materials: 334500
-      service_equipment: LCN
-      operation_reduction: 0.0
-      replacement: true
-      level: 5
-      description: major replacement
+  - scale: 0.0667
+    shape: 1
+    time: 3
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 1
+    description: manual reset
+  - scale: 0.1667
+    shape: 1
+    time: 7.5
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 2
+    description: minor repair
+  - scale: 1.8182
+    shape: 1
+    time: 22
+    materials: 18500
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 3
+    description: medium repair
+  - scale: 12.5
+    shape: 1
+    time: 26
+    materials: 73500
+    service_equipment: SCN
+    operation_reduction: 0.0
+    level: 4
+    description: major repair
+  - scale: 6.25
+    shape: 1
+    time: 52
+    materials: 334500
+    service_equipment: LCN
+    operation_reduction: 0.0
+    replacement: true
+    level: 5
+    description: major replacement

--- a/library/code_comparison/dinwoodie/turbines/vestas_v90_failure_200_100pct_reduction.yaml
+++ b/library/code_comparison/dinwoodie/turbines/vestas_v90_failure_200_100pct_reduction.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
   bin_width: 0.5
@@ -12,49 +12,44 @@ turbine:
     service_equipment: CTV
     frequency: 365
   failures:
-    1:
-      scale: 0.0667
-      shape: 1
-      time: 3
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0.1667
-      shape: 1
-      time: 7.5
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 1.8182
-      shape: 1
-      time: 22
-      materials: 18500
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 12.5
-      shape: 1
-      time: 26
-      materials: 73500
-      service_equipment: SCN
-      operation_reduction: 1.0
-      level: 4
-      description: major repair
-    5:
-      scale: 6.25
-      shape: 1
-      time: 52
-      materials: 334500
-      service_equipment: LCN
-      operation_reduction: 1.0
-      replacement: true
-      level: 5
-      description: major replacement
+  - scale: 0.0667
+    shape: 1
+    time: 3
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 1
+    description: manual reset
+  - scale: 0.1667
+    shape: 1
+    time: 7.5
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 2
+    description: minor repair
+  - scale: 1.8182
+    shape: 1
+    time: 22
+    materials: 18500
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 3
+    description: medium repair
+  - scale: 12.5
+    shape: 1
+    time: 26
+    materials: 73500
+    service_equipment: SCN
+    operation_reduction: 1.0
+    level: 4
+    description: major repair
+  - scale: 6.25
+    shape: 1
+    time: 52
+    materials: 334500
+    service_equipment: LCN
+    operation_reduction: 1.0
+    replacement: true
+    level: 5
+    description: major replacement

--- a/library/code_comparison/dinwoodie/turbines/vestas_v90_failure_50.yaml
+++ b/library/code_comparison/dinwoodie/turbines/vestas_v90_failure_50.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
   bin_width: 0.5
@@ -12,49 +12,44 @@ turbine:
     service_equipment: CTV
     frequency: 365
   failures:
-    1:
-      scale: 0.2666
-      shape: 1
-      time: 3
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0.6667
-      shape: 1
-      time: 7.5
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 7.2726
-      shape: 1
-      time: 22
-      materials: 18500
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 50
-      shape: 1
-      time: 26
-      materials: 73500
-      service_equipment: SCN
-      operation_reduction: 0.0
-      level: 4
-      description: major repair
-    5:
-      scale: 25
-      shape: 1
-      time: 52
-      materials: 334500
-      service_equipment: LCN
-      operation_reduction: 0.0
-      replacement: true
-      level: 5
-      description: major replacement
+  - scale: 0.2666
+    shape: 1
+    time: 3
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 1
+    description: manual reset
+  - scale: 0.6667
+    shape: 1
+    time: 7.5
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 2
+    description: minor repair
+  - scale: 7.2726
+    shape: 1
+    time: 22
+    materials: 18500
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 3
+    description: medium repair
+  - scale: 50
+    shape: 1
+    time: 26
+    materials: 73500
+    service_equipment: SCN
+    operation_reduction: 0.0
+    level: 4
+    description: major repair
+  - scale: 25
+    shape: 1
+    time: 52
+    materials: 334500
+    service_equipment: LCN
+    operation_reduction: 0.0
+    replacement: true
+    level: 5
+    description: major replacement

--- a/library/code_comparison/dinwoodie/turbines/vestas_v90_failure_50_100pct_reduction.yaml
+++ b/library/code_comparison/dinwoodie/turbines/vestas_v90_failure_50_100pct_reduction.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
   bin_width: 0.5
@@ -12,49 +12,44 @@ turbine:
     service_equipment: CTV
     frequency: 365
   failures:
-    1:
-      scale: 0.2666
-      shape: 1
-      time: 3
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0.6667
-      shape: 1
-      time: 7.5
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 7.2726
-      shape: 1
-      time: 22
-      materials: 18500
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 50
-      shape: 1
-      time: 26
-      materials: 73500
-      service_equipment: SCN
-      operation_reduction: 1.0
-      level: 4
-      description: major repair
-    5:
-      scale: 25
-      shape: 1
-      time: 52
-      materials: 334500
-      service_equipment: LCN
-      operation_reduction: 1.0
-      replacement: true
-      level: 5
-      description: major replacement
+  - scale: 0.2666
+    shape: 1
+    time: 3
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 1
+    description: manual reset
+  - scale: 0.6667
+    shape: 1
+    time: 7.5
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 2
+    description: minor repair
+  - scale: 7.2726
+    shape: 1
+    time: 22
+    materials: 18500
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 3
+    description: medium repair
+  - scale: 50
+    shape: 1
+    time: 26
+    materials: 73500
+    service_equipment: SCN
+    operation_reduction: 1.0
+    level: 4
+    description: major repair
+  - scale: 25
+    shape: 1
+    time: 52
+    materials: 334500
+    service_equipment: LCN
+    operation_reduction: 1.0
+    replacement: true
+    level: 5
+    description: major replacement

--- a/library/code_comparison/dinwoodie/turbines/vestas_v90_major_repairs_only.yaml
+++ b/library/code_comparison/dinwoodie/turbines/vestas_v90_major_repairs_only.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
   bin_width: 0.5
@@ -12,49 +12,44 @@ turbine:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 25
-      shape: 1
-      time: 26
-      materials: 73500
-      service_equipment: SCN
-      operation_reduction: 0.0
-      level: 4
-      description: major repair
-    5:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: LCN
-      operation_reduction: 0
-      replacement: true
-      level: 5
-      description: major replacement
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 1
+    description: manual reset
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 2
+    description: minor repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 3
+    description: medium repair
+  - scale: 25
+    shape: 1
+    time: 26
+    materials: 73500
+    service_equipment: SCN
+    operation_reduction: 0.0
+    level: 4
+    description: major repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: LCN
+    operation_reduction: 0
+    replacement: true
+    level: 5
+    description: major replacement

--- a/library/code_comparison/dinwoodie/turbines/vestas_v90_major_repairs_only_100pct_reduction.yaml
+++ b/library/code_comparison/dinwoodie/turbines/vestas_v90_major_repairs_only_100pct_reduction.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
   bin_width: 0.5
@@ -12,49 +12,44 @@ turbine:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 25
-      shape: 1
-      time: 26
-      materials: 73500
-      service_equipment: SCN
-      operation_reduction: 0.0
-      level: 4
-      description: major repair
-    5:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: LCN
-      operation_reduction: 0
-      replacement: true
-      level: 5
-      description: major replacement
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 1
+    description: manual reset
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 2
+    description: minor repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 3
+    description: medium repair
+  - scale: 25
+    shape: 1
+    time: 26
+    materials: 73500
+    service_equipment: SCN
+    operation_reduction: 0.0
+    level: 4
+    description: major repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: LCN
+    operation_reduction: 0
+    replacement: true
+    level: 5
+    description: major replacement

--- a/library/code_comparison/dinwoodie/turbines/vestas_v90_major_replacements_only.yaml
+++ b/library/code_comparison/dinwoodie/turbines/vestas_v90_major_replacements_only.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
   bin_width: 0.5
@@ -12,49 +12,44 @@ turbine:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: SCN
-      operation_reduction: 0.0
-      level: 4
-      description: major repair
-    5:
-      scale: 12.5
-      shape: 1
-      time: 52
-      materials: 334500
-      service_equipment: LCN
-      operation_reduction: 0.0
-      replacement: true
-      level: 5
-      description: major replacement
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 1
+    description: manual reset
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 2
+    description: minor repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 3
+    description: medium repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: SCN
+    operation_reduction: 0.0
+    level: 4
+    description: major repair
+  - scale: 12.5
+    shape: 1
+    time: 52
+    materials: 334500
+    service_equipment: LCN
+    operation_reduction: 0.0
+    replacement: true
+    level: 5
+    description: major replacement

--- a/library/code_comparison/dinwoodie/turbines/vestas_v90_major_replacements_only_100pct_reduction.yaml
+++ b/library/code_comparison/dinwoodie/turbines/vestas_v90_major_replacements_only_100pct_reduction.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
   bin_width: 0.5
@@ -12,49 +12,44 @@ turbine:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: SCN
-      operation_reduction: 1.0
-      level: 4
-      description: major repair
-    5:
-      scale: 12.5
-      shape: 1
-      time: 52
-      materials: 334500
-      service_equipment: LCN
-      operation_reduction: 1.0
-      replacement: true
-      level: 5
-      description: major replacement
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 1
+    description: manual reset
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 2
+    description: minor repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 3
+    description: medium repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: SCN
+    operation_reduction: 1.0
+    level: 4
+    description: major repair
+  - scale: 12.5
+    shape: 1
+    time: 52
+    materials: 334500
+    service_equipment: LCN
+    operation_reduction: 1.0
+    replacement: true
+    level: 5
+    description: major replacement

--- a/library/code_comparison/dinwoodie/turbines/vestas_v90_manual_resets_only.yaml
+++ b/library/code_comparison/dinwoodie/turbines/vestas_v90_manual_resets_only.yaml
@@ -1,9 +1,9 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
   bin_width: 0.5
-turbine::
+'turbine:':
   name: turbine
   maintenance:
   - description: annual service
@@ -12,49 +12,44 @@ turbine::
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0.1333
-      shape: 1
-      time: 3
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: SCN
-      operation_reduction: 0.0
-      level: 4
-      description: major repair
-    5:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: LCN
-      operation_reduction: 0
-      replacement: true
-      level: 5
-      description: major replacement
+  - scale: 0.1333
+    shape: 1
+    time: 3
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 1
+    description: manual reset
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 2
+    description: minor repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 3
+    description: medium repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: SCN
+    operation_reduction: 0.0
+    level: 4
+    description: major repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: LCN
+    operation_reduction: 0
+    replacement: true
+    level: 5
+    description: major replacement

--- a/library/code_comparison/dinwoodie/turbines/vestas_v90_manual_resets_only_100pct_reduction.yaml
+++ b/library/code_comparison/dinwoodie/turbines/vestas_v90_manual_resets_only_100pct_reduction.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
   bin_width: 0.5
@@ -12,49 +12,44 @@ turbine:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0.1333
-      shape: 1
-      time: 3
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: SCN
-      operation_reduction: 1.0
-      level: 4
-      description: major repair
-    5:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: LCN
-      operation_reduction: 0
-      replacement: true
-      level: 5
-      description: major replacement
+  - scale: 0.1333
+    shape: 1
+    time: 3
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 1
+    description: manual reset
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 2
+    description: minor repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 3
+    description: medium repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: SCN
+    operation_reduction: 1.0
+    level: 4
+    description: major repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: LCN
+    operation_reduction: 0
+    replacement: true
+    level: 5
+    description: major replacement

--- a/library/code_comparison/dinwoodie/turbines/vestas_v90_medium_repairs_only.yaml
+++ b/library/code_comparison/dinwoodie/turbines/vestas_v90_medium_repairs_only.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
   bin_width: 0.5
@@ -12,49 +12,44 @@ turbine:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0.0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 3.6363
-      shape: 1
-      time: 22
-      materials: 18500
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: SCN
-      operation_reduction: 0.0
-      level: 4
-      description: major repair
-    5:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: LCN
-      operation_reduction: 0
-      replacement: true
-      level: 5
-      description: major replacement
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 1
+    description: manual reset
+  - scale: 0.0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 2
+    description: minor repair
+  - scale: 3.6363
+    shape: 1
+    time: 22
+    materials: 18500
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 3
+    description: medium repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: SCN
+    operation_reduction: 0.0
+    level: 4
+    description: major repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: LCN
+    operation_reduction: 0
+    replacement: true
+    level: 5
+    description: major replacement

--- a/library/code_comparison/dinwoodie/turbines/vestas_v90_medium_repairs_only_100pct_reduction.yaml
+++ b/library/code_comparison/dinwoodie/turbines/vestas_v90_medium_repairs_only_100pct_reduction.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
   bin_width: 0.5
@@ -12,49 +12,44 @@ turbine:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0.0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 3.6363
-      shape: 1
-      time: 22
-      materials: 18500
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: SCN
-      operation_reduction: 1.0
-      level: 4
-      description: major repair
-    5:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: LCN
-      operation_reduction: 0
-      replacement: true
-      level: 5
-      description: major replacement
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 1
+    description: manual reset
+  - scale: 0.0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 2
+    description: minor repair
+  - scale: 3.6363
+    shape: 1
+    time: 22
+    materials: 18500
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 3
+    description: medium repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: SCN
+    operation_reduction: 1.0
+    level: 4
+    description: major repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: LCN
+    operation_reduction: 0
+    replacement: true
+    level: 5
+    description: major replacement

--- a/library/code_comparison/dinwoodie/turbines/vestas_v90_minor_repairs_only.yaml
+++ b/library/code_comparison/dinwoodie/turbines/vestas_v90_minor_repairs_only.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
   bin_width: 0.5
@@ -12,49 +12,44 @@ turbine:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0.3333
-      shape: 1
-      time: 7.5
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: SCN
-      operation_reduction: 0.0
-      level: 4
-      description: major repair
-    5:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: LCN
-      operation_reduction: 0.0
-      replacement: true
-      level: 5
-      description: major replacement
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 1
+    description: manual reset
+  - scale: 0.3333
+    shape: 1
+    time: 7.5
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 2
+    description: minor repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 3
+    description: medium repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: SCN
+    operation_reduction: 0.0
+    level: 4
+    description: major repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: LCN
+    operation_reduction: 0.0
+    replacement: true
+    level: 5
+    description: major replacement

--- a/library/code_comparison/dinwoodie/turbines/vestas_v90_minor_repairs_only_100pct_reduction.yaml
+++ b/library/code_comparison/dinwoodie/turbines/vestas_v90_minor_repairs_only_100pct_reduction.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
   bin_width: 0.5
@@ -12,49 +12,44 @@ turbine:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0.3333
-      shape: 1
-      time: 7.5
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: SCN
-      operation_reduction: 1.0
-      level: 4
-      description: major repair
-    5:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: LCN
-      operation_reduction: 1.0
-      replacement: true
-      level: 5
-      description: major replacement
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 1
+    description: manual reset
+  - scale: 0.3333
+    shape: 1
+    time: 7.5
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 2
+    description: minor repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 3
+    description: medium repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: SCN
+    operation_reduction: 1.0
+    level: 4
+    description: major repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: LCN
+    operation_reduction: 1.0
+    replacement: true
+    level: 5
+    description: major replacement

--- a/library/code_comparison/dinwoodie/turbines/vestas_v90_no_hlvs.yaml
+++ b/library/code_comparison/dinwoodie/turbines/vestas_v90_no_hlvs.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
   bin_width: 0.5
@@ -12,49 +12,44 @@ turbine:
     service_equipment: CTV
     frequency: 365
   failures:
-    1:
-      scale: 0.1333
-      shape: 1
-      time: 3
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0.3333
-      shape: 1
-      time: 7.5
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 3.6363
-      shape: 1
-      time: 22
-      materials: 18500
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: SCN
-      operation_reduction: 0.0
-      level: 4
-      description: major repair
-    5:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: LCN
-      operation_reduction: 0
-      replacement: true
-      level: 5
-      description: major replacement
+  - scale: 0.1333
+    shape: 1
+    time: 3
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 1
+    description: manual reset
+  - scale: 0.3333
+    shape: 1
+    time: 7.5
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 2
+    description: minor repair
+  - scale: 3.6363
+    shape: 1
+    time: 22
+    materials: 18500
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 3
+    description: medium repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: SCN
+    operation_reduction: 0.0
+    level: 4
+    description: major repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: LCN
+    operation_reduction: 0
+    replacement: true
+    level: 5
+    description: major replacement

--- a/library/code_comparison/dinwoodie/turbines/vestas_v90_no_hlvs_100pct_reduction.yaml
+++ b/library/code_comparison/dinwoodie/turbines/vestas_v90_no_hlvs_100pct_reduction.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
   bin_width: 0.5
@@ -12,49 +12,44 @@ turbine:
     service_equipment: CTV
     frequency: 365
   failures:
-    1:
-      scale: 0.1333
-      shape: 1
-      time: 3
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0.3333
-      shape: 1
-      time: 7.5
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 3.6363
-      shape: 1
-      time: 22
-      materials: 18500
-      service_equipment: CTV
-      operation_reduction: 1.0
-      replacement: true
-      level: 3
-      description: medium repair
-    4:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: SCN
-      operation_reduction: 1.0
-      level: 4
-      description: major repair
-    5:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: LCN
-      operation_reduction: 0
-      level: 5
-      description: major replacement
+  - scale: 0.1333
+    shape: 1
+    time: 3
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 1
+    description: manual reset
+  - scale: 0.3333
+    shape: 1
+    time: 7.5
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 2
+    description: minor repair
+  - scale: 3.6363
+    shape: 1
+    time: 22
+    materials: 18500
+    service_equipment: CTV
+    operation_reduction: 1.0
+    replacement: true
+    level: 3
+    description: medium repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: SCN
+    operation_reduction: 1.0
+    level: 4
+    description: major repair
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: LCN
+    operation_reduction: 0
+    level: 5
+    description: major replacement

--- a/library/code_comparison/dinwoodie/turbines/vestas_v90_tow_to_port.yaml
+++ b/library/code_comparison/dinwoodie/turbines/vestas_v90_tow_to_port.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
   bin_width: 0.5
@@ -12,49 +12,44 @@ turbine:
     service_equipment: CTV
     frequency: 365
   failures:
-    1:
-      scale: 0.1333
-      shape: 1
-      time: 3
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0.3333
-      shape: 1
-      time: 7.5
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 3.6363
-      shape: 1
-      time: 22
-      materials: 18500
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 25
-      shape: 1
-      time: 26
-      materials: 73500
-      service_equipment: TOW
-      operation_reduction: 0.0
-      level: 4
-      description: major repair
-    5:
-      scale: 12.5
-      shape: 1
-      time: 52
-      materials: 334500
-      service_equipment: TOW
-      operation_reduction: 0.0
-      replacement: true
-      level: 5
-      description: major replacement
+  - scale: 0.1333
+    shape: 1
+    time: 3
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 1
+    description: manual reset
+  - scale: 0.3333
+    shape: 1
+    time: 7.5
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 2
+    description: minor repair
+  - scale: 3.6363
+    shape: 1
+    time: 22
+    materials: 18500
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 3
+    description: medium repair
+  - scale: 25
+    shape: 1
+    time: 26
+    materials: 73500
+    service_equipment: TOW
+    operation_reduction: 0.0
+    level: 4
+    description: major repair
+  - scale: 12.5
+    shape: 1
+    time: 52
+    materials: 334500
+    service_equipment: TOW
+    operation_reduction: 0.0
+    replacement: true
+    level: 5
+    description: major replacement

--- a/library/code_comparison/iea26/cables/array_33kv_240mm.yaml
+++ b/library/code_comparison/iea26/cables/array_33kv_240mm.yaml
@@ -1,19 +1,18 @@
 name: array cable
 maintenance:
-  -
-    description: n/a
-    time: 0
-    materials: 0
-    service_equipment: CTV
-    frequency: 0
+- description: n/a
+  time: 0
+  materials: 0
+  service_equipment: CTV
+  frequency: 0
 failures:
-  5:
-    scale: 2500
-    shape: 1
-    time: 32
-    materials: 350000
-    operation_reduction: 1
-    service_equipment: [CAB]
-    replacement: true
-    level: 5
-    description: cable replacement
+- scale: 2500
+  shape: 1
+  time: 32
+  materials: 350000
+  operation_reduction: 1
+  service_equipment:
+  - CAB
+  replacement: true
+  level: 5
+  description: cable replacement

--- a/library/code_comparison/iea26/cables/array_33kv_630mm.yaml
+++ b/library/code_comparison/iea26/cables/array_33kv_630mm.yaml
@@ -1,19 +1,18 @@
 name: array cable
 maintenance:
-  -
-    description: n/a
-    time: 0
-    materials: 0
-    service_equipment: CTV
-    frequency: 0
+- description: n/a
+  time: 0
+  materials: 0
+  service_equipment: CTV
+  frequency: 0
 failures:
-  5:
-    scale: 2500
-    shape: 1
-    time: 32
-    materials: 350000
-    operation_reduction: 1
-    service_equipment: [CAB]
-    replacement: true
-    level: 5
-    description: cable replacement
+- scale: 2500
+  shape: 1
+  time: 32
+  materials: 350000
+  operation_reduction: 1
+  service_equipment:
+  - CAB
+  replacement: true
+  level: 5
+  description: cable replacement

--- a/library/code_comparison/iea26/cables/export_220kv_1600mm.yaml
+++ b/library/code_comparison/iea26/cables/export_220kv_1600mm.yaml
@@ -1,19 +1,18 @@
 name: array cable
 maintenance:
-  -
-    description: n/a
-    time: 0
-    materials: 0
-    service_equipment: CTV
-    frequency: 0
+- description: n/a
+  time: 0
+  materials: 0
+  service_equipment: CTV
+  frequency: 0
 failures:
-  4:
-    scale: 2
-    shape: 1
-    time: 32
-    materials: 400000  # 350,000 EUR round up to 400,000 USD
-    operation_reduction: 1
-    service_equipment: [CAB]
-    replacement: true
-    level: 4
-    description: cable replacement
+- scale: 2
+  shape: 1
+  time: 32
+  materials: 400000
+  operation_reduction: 1
+  service_equipment:
+  - CAB
+  replacement: true
+  level: 4
+  description: cable replacement

--- a/library/code_comparison/iea26/substations/offshore_substation.yaml
+++ b/library/code_comparison/iea26/substations/offshore_substation.yaml
@@ -1,48 +1,47 @@
 capacity_kw: 670000
-capex_kw: 140  # 120,000 EUR/MW rounded to 140 USD/kW; https://guidetoanoffshorewindfarm.com/wind-farm-costs
+capex_kw: 140
 transformer:
   name: transformer
   maintenance:
-    -
-      description: substation inspection
-      time: 3
-      materials: 500
-      service_equipment: CTV
-      frequency: 91
+  - description: substation inspection
+    time: 3
+    materials: 500
+    service_equipment: CTV
+    frequency: 91
   failures:
-    1:
-      scale: 2.2222
-      shape: 1
-      time: 8
-      materials: 5000
-      service_equipment: [CTV]
-      operation_reduction: 0
-      level: 1
-      description: small transformer repair
-    2:
-      scale: 2.2222
-      shape: 1
-      time: 8
-      materials: 5000
-      service_equipment: [CTV]
-      operation_reduction: 0
-      level: 2
-      description: small transformer repair
-    3:
-      scale: 20.0
-      shape: 1
-      time: 48
-      materials: 250000
-      service_equipment: [CTV]
-      operation_reduction: 0
-      level: 3
-      description: large transformer repair
-    4:
-      scale: 20.0
-      shape: 1
-      time: 48
-      materials: 250000
-      service_equipment: [CTV]
-      operation_reduction: 0
-      level: 4
-      description: large transformer repair
+  - scale: 2.2222
+    shape: 1
+    time: 8
+    materials: 5000
+    service_equipment:
+    - CTV
+    operation_reduction: 0
+    level: 1
+    description: small transformer repair
+  - scale: 2.2222
+    shape: 1
+    time: 8
+    materials: 5000
+    service_equipment:
+    - CTV
+    operation_reduction: 0
+    level: 2
+    description: small transformer repair
+  - scale: 20.0
+    shape: 1
+    time: 48
+    materials: 250000
+    service_equipment:
+    - CTV
+    operation_reduction: 0
+    level: 3
+    description: large transformer repair
+  - scale: 20.0
+    shape: 1
+    time: 48
+    materials: 250000
+    service_equipment:
+    - CTV
+    operation_reduction: 0
+    level: 4
+    description: large transformer repair

--- a/library/code_comparison/iea26/substations/offshore_substation_100pct_reduction.yaml
+++ b/library/code_comparison/iea26/substations/offshore_substation_100pct_reduction.yaml
@@ -1,48 +1,47 @@
 capacity_kw: 670000
-capex_kw: 140  # 120,000 EUR/MW rounded to 140 USD/kW; https://guidetoanoffshorewindfarm.com/wind-farm-costs
+capex_kw: 140
 transformer:
   name: transformer
   maintenance:
-    -
-      description: substation inspection
-      time: 3
-      materials: 500
-      service_equipment: CTV
-      frequency: 91
+  - description: substation inspection
+    time: 3
+    materials: 500
+    service_equipment: CTV
+    frequency: 91
   failures:
-    1:
-      scale: 2.2222
-      shape: 1
-      time: 8
-      materials: 5000
-      service_equipment: [CTV]
-      operation_reduction: 1
-      level: 1
-      description: small transformer repair
-    2:
-      scale: 2.2222
-      shape: 1
-      time: 8
-      materials: 5000
-      service_equipment: [CTV]
-      operation_reduction: 1
-      level: 2
-      description: small transformer repair
-    3:
-      scale: 20.0
-      shape: 1
-      time: 48
-      materials: 250000
-      service_equipment: [CTV]
-      operation_reduction: 1
-      level: 3
-      description: large transformer repair
-    4:
-      scale: 20.0
-      shape: 1
-      time: 48
-      materials: 250000
-      service_equipment: [CTV]
-      operation_reduction: 1
-      level: 4
-      description: large transformer repair
+  - scale: 2.2222
+    shape: 1
+    time: 8
+    materials: 5000
+    service_equipment:
+    - CTV
+    operation_reduction: 1
+    level: 1
+    description: small transformer repair
+  - scale: 2.2222
+    shape: 1
+    time: 8
+    materials: 5000
+    service_equipment:
+    - CTV
+    operation_reduction: 1
+    level: 2
+    description: small transformer repair
+  - scale: 20.0
+    shape: 1
+    time: 48
+    materials: 250000
+    service_equipment:
+    - CTV
+    operation_reduction: 1
+    level: 3
+    description: large transformer repair
+  - scale: 20.0
+    shape: 1
+    time: 48
+    materials: 250000
+    service_equipment:
+    - CTV
+    operation_reduction: 1
+    level: 4
+    description: large transformer repair

--- a/library/code_comparison/iea26/turbines/turbine_csm_4mw.yaml
+++ b/library/code_comparison/iea26/turbines/turbine_csm_4mw.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 4000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: turbine_csm_4mw_power_curve.csv
   bin_width: 0.5
@@ -12,53 +12,47 @@ generator:
     service_equipment: CTV
     frequency: 365
   failures:
-    #  NOT MODELING REMOTE RESETS FOR NOW
-    1:
-      scale: 0.14289
-      shape: 1
-      time: 2
-      materials: 0
-      service_equipment: RMT
-      operation_reduction: 0.0
-      level: 1
-      description: remote reset
-    2:
-      scale: 0.2
-      shape: 1
-      time: 3
-      materials: 238
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 2
-      description: manual reset
-    3:
-      scale: 0.3333
-      shape: 1
-      time: 7.5
-      materials: 5279
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 3
-      description: minor repair
-    4:
-      scale: 3.3333
-      shape: 1
-      time: 29.5  # has 7.5hr inspection time baked in
-      materials: 29230
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 4
-      description: major repair
-    5:
-      scale: 9.0909
-      shape: 1
-      time: 41.5  # has 7.5hr inspection time baked in
-      materials: 441373
-      service_equipment: LCN
-      operation_reduction: 0.0
-      replacement: true
-      level: 5
-      description: major replacement
+  - scale: 0.14289
+    shape: 1
+    time: 2
+    materials: 0
+    service_equipment: RMT
+    operation_reduction: 0.0
+    level: 1
+    description: remote reset
+  - scale: 0.2
+    shape: 1
+    time: 3
+    materials: 238
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 2
+    description: manual reset
+  - scale: 0.3333
+    shape: 1
+    time: 7.5
+    materials: 5279
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 3
+    description: minor repair
+  - scale: 3.3333
+    shape: 1
+    time: 29.5
+    materials: 29230
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 4
+    description: major repair
+  - scale: 9.0909
+    shape: 1
+    time: 41.5
+    materials: 441373
+    service_equipment: LCN
+    operation_reduction: 0.0
+    replacement: true
+    level: 5
+    description: major replacement
 supporting_structure:
   name: supporting_structure
   maintenance:
@@ -68,12 +62,11 @@ supporting_structure:
     service_equipment: CTV
     frequency: 365
   failures:
-    3:
-      scale: 43.4783
-      shape: 1
-      time: 8
-      materials: 5000
-      service_equipment: DSV
-      operation_reduction: 0
-      level: 3
-      description: small foundation/scour repair
+  - scale: 43.4783
+    shape: 1
+    time: 8
+    materials: 5000
+    service_equipment: DSV
+    operation_reduction: 0
+    level: 3
+    description: small foundation/scour repair

--- a/library/code_comparison/iea26/turbines/turbine_csm_4mw_100pct_reduction.yaml
+++ b/library/code_comparison/iea26/turbines/turbine_csm_4mw_100pct_reduction.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 4000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: turbine_csm_4mw_power_curve.csv
   bin_width: 0.5
@@ -12,53 +12,47 @@ generator:
     service_equipment: CTV
     frequency: 365
   failures:
-    #  NOT MODELING REMOTE RESETS FOR NOW
-    1:
-      scale: 0.14289
-      shape: 1
-      time: 2
-      materials: 0
-      service_equipment: RMT
-      operation_reduction: 1.0
-      level: 1
-      description: remote reset
-    2:
-      scale: 0.2
-      shape: 1
-      time: 3
-      materials: 238
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 2
-      description: manual reset
-    3:
-      scale: 0.3333
-      shape: 1
-      time: 7.5
-      materials: 5279
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 3
-      description: minor repair
-    4:
-      scale: 3.3333
-      shape: 1
-      time: 29.5  # has 7.5hr inspection time baked in
-      materials: 29230
-      service_equipment: CTV
-      operation_reduction: 1.0
-      level: 4
-      description: major repair
-    5:
-      scale: 9.0909
-      shape: 1
-      time: 41.5  # has 7.5hr inspection time baked in
-      materials: 441373
-      service_equipment: LCN
-      operation_reduction: 1.0
-      replacement: true
-      level: 5
-      description: major replacement
+  - scale: 0.14289
+    shape: 1
+    time: 2
+    materials: 0
+    service_equipment: RMT
+    operation_reduction: 1.0
+    level: 1
+    description: remote reset
+  - scale: 0.2
+    shape: 1
+    time: 3
+    materials: 238
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 2
+    description: manual reset
+  - scale: 0.3333
+    shape: 1
+    time: 7.5
+    materials: 5279
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 3
+    description: minor repair
+  - scale: 3.3333
+    shape: 1
+    time: 29.5
+    materials: 29230
+    service_equipment: CTV
+    operation_reduction: 1.0
+    level: 4
+    description: major repair
+  - scale: 9.0909
+    shape: 1
+    time: 41.5
+    materials: 441373
+    service_equipment: LCN
+    operation_reduction: 1.0
+    replacement: true
+    level: 5
+    description: major replacement
 supporting_structure:
   name: supporting_structure
   maintenance:
@@ -68,12 +62,11 @@ supporting_structure:
     service_equipment: CTV
     frequency: 365
   failures:
-    3:
-      scale: 43.4783
-      shape: 1
-      time: 8
-      materials: 5000
-      service_equipment: DSV
-      operation_reduction: 1
-      level: 3
-      description: small foundation/scour repair
+  - scale: 43.4783
+    shape: 1
+    time: 8
+    materials: 5000
+    service_equipment: DSV
+    operation_reduction: 1
+    level: 3
+    description: small foundation/scour repair

--- a/library/corewind/cables/corewind_array.yaml
+++ b/library/corewind/cables/corewind_array.yaml
@@ -1,31 +1,28 @@
 name: array cable
 maintenance:
-  -
-    description: n/a
-    time: 0
-    materials: 0
-    service_equipment: CTV
-    frequency: 0
+- description: n/a
+  time: 0
+  materials: 0
+  service_equipment: CTV
+  frequency: 0
 failures:
-  4:
-    scale: 40
-    shape: 1
-    time: 240
-    materials: 30000
-    operation_reduction: 0
-    service_equipment: [CAB]
-    replacement: false
-    level: 4
-    description: array cable major repair
-    # n_technicians: 10
-  6:
-    scale: 62.5
-    shape: 1
-    time: 360
-    materials: 220000
-    operation_reduction: 0
-    service_equipment: [CAB]
-    replacement: true
-    level: 6
-    description: array cable replacement
-    # n_technicians: 10
+- scale: 40
+  shape: 1
+  time: 240
+  materials: 30000
+  operation_reduction: 0
+  service_equipment:
+  - CAB
+  replacement: false
+  level: 4
+  description: array cable major repair
+- scale: 62.5
+  shape: 1
+  time: 360
+  materials: 220000
+  operation_reduction: 0
+  service_equipment:
+  - CAB
+  replacement: true
+  level: 6
+  description: array cable replacement

--- a/library/corewind/cables/corewind_export.yaml
+++ b/library/corewind/cables/corewind_export.yaml
@@ -1,22 +1,19 @@
 name: export cable
 maintenance:
-  -
-    description: export cable subsea inspection
-    time: 12
-    materials: 500
-    service_equipment: DSV
-    frequency: 730
-    level: 1
-    # n_technicians: 5
+- description: export cable subsea inspection
+  time: 12
+  materials: 500
+  service_equipment: DSV
+  frequency: 730
+  level: 1
 failures:
-  6:
-    scale: 50
-    shape: 1
-    time: 60
-    materials: 30000
-    operation_reduction: 0
-    service_equipment: [CAB]
-    replacement: false
-    level: 4
-    description: export cable major repair
-    # n_technicians: 5
+- scale: 50
+  shape: 1
+  time: 60
+  materials: 30000
+  operation_reduction: 0
+  service_equipment:
+  - CAB
+  replacement: false
+  level: 4
+  description: export cable major repair

--- a/library/corewind/project/config/morro_bay_in_situ_consolidated.yaml
+++ b/library/corewind/project/config/morro_bay_in_situ_consolidated.yaml
@@ -1,14 +1,14 @@
 name: COREWIND Morro Bay In Situ
 weather: central_ca.csv
 service_equipment:
-  - - ctv
-    - 7
-  - cab
-  - dsv
-  - ahv
-  - hlv
+- - ctv
+  - 7
+- cab
+- dsv
+- ahv
+- hlv
 layout: morro_bay_9D_layout.csv
-port_distance: 60  # 20/100 for West of Barra Island; 10 for Gran Canaria Island
+port_distance: 60
 inflation_rate: 0
 workday_start: 6
 workday_end: 22
@@ -18,95 +18,83 @@ project_capacity: 1200
 substations:
   corewind_substation:
     capacity_kw: 600
-    capex_kw: 120  # 120,000 EUR/MW; https://guidetoanoffshorewindfarm.com/wind-farm-costs
+    capex_kw: 120
     transformer:
       name: transformer
       maintenance:
-        -
-          description: oss annual inspection
-          time: 24
-          materials: 500
-          service_equipment: CTV
-          frequency: 365
-          level: 1
-        # n_technicians: 4
+      - description: oss annual inspection
+        time: 24
+        materials: 500
+        service_equipment: CTV
+        frequency: 365
+        level: 1
       failures:
-        2:
-          scale: 5
-          shape: 1
-          time: 12
-          materials: 2000
-          service_equipment: CTV
-          operation_reduction: 0
-          level: 2
-          description: oss minor repair
-          # n_technicians: 2
-        4:
-          scale: 100
-          shape: 1
-          time: 60
-          materials: 100000
-          service_equipment: CTV
-          operation_reduction: 0
-          level: 4
-          description: oss major repair
-          # n_technicians: 5
+      - scale: 5
+        shape: 1
+        time: 12
+        materials: 2000
+        service_equipment: CTV
+        operation_reduction: 0
+        level: 2
+        description: oss minor repair
+      - scale: 100
+        shape: 1
+        time: 60
+        materials: 100000
+        service_equipment: CTV
+        operation_reduction: 0
+        level: 4
+        description: oss major repair
 cables:
   corewind_export:
     name: export cable
     maintenance:
-      -
-        description: export cable subsea inspection
-        time: 12
-        materials: 500
-        service_equipment: DSV
-        frequency: 730
-        level: 1
-        # n_technicians: 5
+    - description: export cable subsea inspection
+      time: 12
+      materials: 500
+      service_equipment: DSV
+      frequency: 730
+      level: 1
     failures:
-      6:
-        scale: 50
-        shape: 1
-        time: 60
-        materials: 30000
-        operation_reduction: 0
-        service_equipment: [CAB]
-        replacement: false
-        level: 4
-        description: export cable major repair
-        # n_technicians: 5
+    - scale: 50
+      shape: 1
+      time: 60
+      materials: 30000
+      operation_reduction: 0
+      service_equipment:
+      - CAB
+      replacement: false
+      level: 4
+      description: export cable major repair
   corewind_array:
     name: array cable
     maintenance:
-      -
-        description: n/a
-        time: 0
-        materials: 0
-        service_equipment: CTV
-        frequency: 0
+    - description: n/a
+      time: 0
+      materials: 0
+      service_equipment: CTV
+      frequency: 0
     failures:
-      4:
-        scale: 40
-        shape: 1
-        time: 240
-        materials: 30000
-        operation_reduction: 0
-        service_equipment: [CAB]
-        replacement: false
-        level: 4
-        description: array cable major repair
-        # n_technicians: 10
-      6:
-        scale: 62.5
-        shape: 1
-        time: 360
-        materials: 220000
-        operation_reduction: 0
-        service_equipment: [CAB]
-        replacement: true
-        level: 6
-        description: array cable replacement
-        # n_technicians: 10
+    - scale: 40
+      shape: 1
+      time: 240
+      materials: 30000
+      operation_reduction: 0
+      service_equipment:
+      - CAB
+      replacement: false
+      level: 4
+      description: array cable major repair
+    - scale: 62.5
+      shape: 1
+      time: 360
+      materials: 220000
+      operation_reduction: 0
+      service_equipment:
+      - CAB
+      replacement: true
+      level: 6
+      description: array cable replacement
 turbines:
   corewind_15MW:
     capacity_kw: 15000
@@ -123,68 +111,56 @@ turbines:
         service_equipment: CTV
         frequency: 0
       failures:
-        1:
-          scale: 1.859
-          shape: 1
-          time: 14
-          materials: 1000
-          service_equipment: CTV
-          operation_reduction: 0.0
-          level: 1
-          description: power converter minor repair
-          # n_technicians: 2
-        2:
-          scale: 2.793
-          shape: 1
-          time: 10
-          materials: 1000
-          service_equipment: CTV
-          operation_reduction: 0.0
-          level: 2
-          description: power electrical system minor repair
-          # n_technicians: 2
-        3:
-          scale: 2.959
-          shape: 1
-          time: 28
-          materials: 7000
-          service_equipment: LCN
-          operation_reduction: 0.0
-          level: 3
-          description: power converter major repair
-          # n_technicians: 3
-        4:
-          scale: 62.5
-          shape: 1
-          time: 28
-          materials: 5000
-          service_equipment: LCN
-          operation_reduction: 0.0
-          level: 4
-          description: power electrical system major repair
-          # n_technicians: 3
-        5:
-          scale: 12.99
-          shape: 1
-          time: 170
-          materials: 55000
-          service_equipment: LCN
-          operation_reduction: 0
-          replacement: true
-          level: 5
-          description: power converter replacement
-          # n_technicians: 4
-        6:
-          scale: 500
-          shape: 1
-          time: 54
-          materials: 50000
-          service_equipment: LCN
-          operation_reduction: 0
-          replacement: true
-          level: 6
-          description: power electrical system major replacement
-          # n_technicians: 4
+      - scale: 1.859
+        shape: 1
+        time: 14
+        materials: 1000
+        service_equipment: CTV
+        operation_reduction: 0.0
+        level: 1
+        description: power converter minor repair
+      - scale: 2.793
+        shape: 1
+        time: 10
+        materials: 1000
+        service_equipment: CTV
+        operation_reduction: 0.0
+        level: 2
+        description: power electrical system minor repair
+      - scale: 2.959
+        shape: 1
+        time: 28
+        materials: 7000
+        service_equipment: LCN
+        operation_reduction: 0.0
+        level: 3
+        description: power converter major repair
+      - scale: 62.5
+        shape: 1
+        time: 28
+        materials: 5000
+        service_equipment: LCN
+        operation_reduction: 0.0
+        level: 4
+        description: power electrical system major repair
+      - scale: 12.99
+        shape: 1
+        time: 170
+        materials: 55000
+        service_equipment: LCN
+        operation_reduction: 0
+        replacement: true
+        level: 5
+        description: power converter replacement
+      - scale: 500
+        shape: 1
+        time: 54
+        materials: 50000
+        service_equipment: LCN
+        operation_reduction: 0
+        replacement: true
+        level: 6
+        description: power electrical system major replacement
     hydraulic_system:
       name: hydraulic_system
       maintenance:
@@ -194,47 +170,39 @@ turbines:
         service_equipment: CTV
         frequency: 0
       failures:
-        1:
-          scale: 1.214
-          shape: 1
-          time: 18
-          materials: 500
-          service_equipment: CTV
-          operation_reduction: 0
-          level: 1
-          description: minor pitch system repair
-          # n_technicians: 2
-        2:
-          scale: 100
-          shape: 1
-          time: 8
-          materials: 1000
-          service_equipment: CTV
-          operation_reduction: 0
-          level: 2
-          description: minor ballast pump repair
-          # n_technicians: 2
-        3:
-          scale: 5.587
-          shape: 1
-          time: 38
-          materials: 1900
-          service_equipment: CTV
-          operation_reduction: 0.0
-          level: 3
-          description: major pitch system repair
-          # n_technicians: 3
-        5:
-          scale: 1000
-          shape: 1
-          time: 75
-          materials: 14000
-          service_equipment: LCN
-          operation_reduction: 0
-          replacement: true
-          level: 5
-          description: major pitch system replacement
-          # n_technicians: 4
+      - scale: 1.214
+        shape: 1
+        time: 18
+        materials: 500
+        service_equipment: CTV
+        operation_reduction: 0
+        level: 1
+        description: minor pitch system repair
+      - scale: 100
+        shape: 1
+        time: 8
+        materials: 1000
+        service_equipment: CTV
+        operation_reduction: 0
+        level: 2
+        description: minor ballast pump repair
+      - scale: 5.587
+        shape: 1
+        time: 38
+        materials: 1900
+        service_equipment: CTV
+        operation_reduction: 0.0
+        level: 3
+        description: major pitch system repair
+      - scale: 1000
+        shape: 1
+        time: 75
+        materials: 14000
+        service_equipment: LCN
+        operation_reduction: 0
+        replacement: true
+        level: 5
+        description: major pitch system replacement
     yaw_system:
       name: yaw_system
       maintenance:
@@ -244,37 +212,31 @@ turbines:
         service_equipment: CTV
         frequency: 0
       failures:
-        1:
-          scale: 6.173
-          shape: 1
-          time: 10
-          materials: 500
-          service_equipment: CTV
-          operation_reduction: 0
-          level: 1
-          description: yaw system minor repair
-          # n_technicians: 2
-        3:
-          scale: 166.7
-          shape: 1
-          time: 40
-          materials: 3000
-          service_equipment: LCN
-          operation_reduction: 0.0
-          level: 3
-          description: yaw system major repair
-          # n_technicians: 3
-        5:
-          scale: 1000
-          shape: 1
-          time: 147
-          materials: 12500
-          service_equipment: LCN
-          operation_reduction: 0
-          replacement: true
-          level: 5
-          description: yaw system major replacement
-          # n_technicians: 5
+      - scale: 6.173
+        shape: 1
+        time: 10
+        materials: 500
+        service_equipment: CTV
+        operation_reduction: 0
+        level: 1
+        description: yaw system minor repair
+      - scale: 166.7
+        shape: 1
+        time: 40
+        materials: 3000
+        service_equipment: LCN
+        operation_reduction: 0.0
+        level: 3
+        description: yaw system major repair
+      - scale: 1000
+        shape: 1
+        time: 147
+        materials: 12500
+        service_equipment: LCN
+        operation_reduction: 0
+        replacement: true
+        level: 5
+        description: yaw system major replacement
     rotor_blades:
       name: rotor_blades
       maintenance:
@@ -284,37 +246,31 @@ turbines:
         service_equipment: CTV
         frequency: 0
       failures:
-        2:
-          scale: 2.193
-          shape: 1
-          time: 18
-          materials: 6000
-          service_equipment: CTV
-          operation_reduction: 0
-          level: 2
-          description: blades minor repair
-          # n_technicians: 2
-        4:
-          scale: 100
-          shape: 1
-          time: 42
-          materials: 51732
-          service_equipment: LCN
-          operation_reduction: 0.0
-          level: 4
-          description: blades major repair
-          # n_technicians: 3
-        6:
-          scale: 1000
-          shape: 1
-          time: 864
-          materials: 534000
-          service_equipment: LCN
-          operation_reduction: 0
-          replacement: true
-          level: 6
-          description: blades major replacement
-          # n_technicians: 21
+      - scale: 2.193
+        shape: 1
+        time: 18
+        materials: 6000
+        service_equipment: CTV
+        operation_reduction: 0
+        level: 2
+        description: blades minor repair
+      - scale: 100
+        shape: 1
+        time: 42
+        materials: 51732
+        service_equipment: LCN
+        operation_reduction: 0.0
+        level: 4
+        description: blades major repair
+      - scale: 1000
+        shape: 1
+        time: 864
+        materials: 534000
+        service_equipment: LCN
+        operation_reduction: 0
+        replacement: true
+        level: 6
+        description: blades major replacement
     generator:
       name: generator
       maintenance:
@@ -323,39 +279,32 @@ turbines:
         materials: 1500
         service_equipment: CTV
         frequency: 365
-        # n_technicians: 3
       failures:
-        2:
-          scale: 1.832
-          shape: 1
-          time: 13
-          materials: 1000
-          service_equipment: CTV
-          operation_reduction: 0.0
-          level: 2
-          description: direct drive generator minor repair
-          # n_technicians: 2
-        4:
-          scale: 33.333
-          shape: 1
-          time: 49
-          materials: 14340
-          service_equipment: LCN
-          operation_reduction: 0.0
-          level: 4
-          description: direct drive generator major repair
-          # n_technicians: 3
-        6:
-          scale: 111.1111
-          shape: 1
-          time: 244
-          materials: 236500
-          service_equipment: LCN
-          operation_reduction: 0
-          replacement: true
-          level: 6
-          description: direct drive generator major replacement
-          # n_technicians: 8
+      - scale: 1.832
+        shape: 1
+        time: 13
+        materials: 1000
+        service_equipment: CTV
+        operation_reduction: 0.0
+        level: 2
+        description: direct drive generator minor repair
+      - scale: 33.333
+        shape: 1
+        time: 49
+        materials: 14340
+        service_equipment: LCN
+        operation_reduction: 0.0
+        level: 4
+        description: direct drive generator major repair
+      - scale: 111.1111
+        shape: 1
+        time: 244
+        materials: 236500
+        service_equipment: LCN
+        operation_reduction: 0
+        replacement: true
+        level: 6
+        description: direct drive generator major replacement
     supporting_structure:
       name: supporting_structure
       maintenance:
@@ -364,77 +313,63 @@ turbines:
         materials: 600
         service_equipment: CTV
         frequency: 365
-        # n_technicians: 4
       - description: structural subsea inspection
         time: 6
         materials: 500
         service_equipment: DSV
         frequency: 730
-        # n_technicians: 5
       failures:
-        1:
-          scale: 8.33
-          shape: 1
-          time: 40
-          materials: 1500
-          service_equipment: CTV
-          operation_reduction: 0
-          level: 1
-          description: marine growth removal
-          # n_technicians: 5
-        2:
-          scale: 66.67
-          shape: 1
-          time: 240
-          materials: 75000
-          service_equipment: AHV
-          operation_reduction: 0
-          level: 2
-          description: major anchor repair
-          # n_technicians: 10
-        3:
-          scale: 66.67
-          shape: 1
-          time: 240
-          materials: 20000
-          service_equipment: AHV
-          operation_reduction: 0
-          level: 3
-          description: mooring line major repair
-          # n_technicians: 10
-        4:
-          scale: 80
-          shape: 1
-          time: 360
-          materials: 512000
-          service_equipment: AHV
-          operation_reduction: 0
-          replacement: true
-          level: 4
-          description: anchor replacement
-          # n_technicians: 10
-        5:
-          scale: 80
-          shape: 1
-          time: 360
-          materials: 135000
-          service_equipment: AHV
-          operation_reduction: 0
-          replacement: true
-          level: 5
-          description: mooring line replacement
-          # n_technicians: 10
-        6:
-          scale: 30.3
-          shape: 1
-          time: 40
-          materials: 100000
-          service_equipment: CTV
-          operation_reduction: 0
-          replacement: true
-          level: 6
-          description: buoyancy module replacement
-          # n_technicians: 5
+      - scale: 8.33
+        shape: 1
+        time: 40
+        materials: 1500
+        service_equipment: CTV
+        operation_reduction: 0
+        level: 1
+        description: marine growth removal
+      - scale: 66.67
+        shape: 1
+        time: 240
+        materials: 75000
+        service_equipment: AHV
+        operation_reduction: 0
+        level: 2
+        description: major anchor repair
+      - scale: 66.67
+        shape: 1
+        time: 240
+        materials: 20000
+        service_equipment: AHV
+        operation_reduction: 0
+        level: 3
+        description: mooring line major repair
+      - scale: 80
+        shape: 1
+        time: 360
+        materials: 512000
+        service_equipment: AHV
+        operation_reduction: 0
+        replacement: true
+        level: 4
+        description: anchor replacement
+      - scale: 80
+        shape: 1
+        time: 360
+        materials: 135000
+        service_equipment: AHV
+        operation_reduction: 0
+        replacement: true
+        level: 5
+        description: mooring line replacement
+      - scale: 30.3
+        shape: 1
+        time: 40
+        materials: 100000
+        service_equipment: CTV
+        operation_reduction: 0
+        replacement: true
+        level: 6
+        description: buoyancy module replacement
     drive_train:
       name: drive_train
       maintenance:
@@ -444,49 +379,43 @@ turbines:
         service_equipment: CTV
         frequency: 0
       failures:
-        2:
-          scale: 4.329
-          shape: 1
-          time: 10
-          materials: 1000
-          service_equipment: CTV
-          operation_reduction: 0
-          level: 2
-          description: main shaft minor repair
-          # n_technicians: 2
-        4:
-          scale: 38.462
-          shape: 1
-          time: 36
-          materials: 14000
-          service_equipment: LCN
-          operation_reduction: 0
-          level: 4
-          description: main shaft major repair
-          # n_technicians: 3
-        6:
-          scale: 111.111
-          shape: 1
-          time: 144
-          materials: 232000
-          service_equipment: LCN
-          operation_reduction: 0
-          replacement: true
-          level: 6
-          description: main shaft replacement
-          # n_technicians: 5
+      - scale: 4.329
+        shape: 1
+        time: 10
+        materials: 1000
+        service_equipment: CTV
+        operation_reduction: 0
+        level: 2
+        description: main shaft minor repair
+      - scale: 38.462
+        shape: 1
+        time: 36
+        materials: 14000
+        service_equipment: LCN
+        operation_reduction: 0
+        level: 4
+        description: main shaft major repair
+      - scale: 111.111
+        shape: 1
+        time: 144
+        materials: 232000
+        service_equipment: LCN
+        operation_reduction: 0
+        replacement: true
+        level: 6
+        description: main shaft replacement
 vessels:
   ctv:
     name: Crew Transfer Vessel
     equipment_rate: 3500
     capability: CTV
-    speed: 37.04  # 20 knots
+    speed: 37.04
     strategy: scheduled
     max_windspeed_transport: 99
     max_windspeed_repair: 99
     max_waveheight_transport: 2
     max_waveheight_repair: 2
-    onsite: True
+    onsite: true
     mobilization_cost: 0
     mobilization_days: 0
     port_distance: 30
@@ -499,16 +428,15 @@ vessels:
     crew_transfer_time: 0.25
     n_crews: 1
     crew:
-      day_rate: 219.18  # 80K/yr / 365 days
-      n_day_rate: 3  # Most tasks are 2, but some larger ones are 3, 4, or 5, so averaging
+      day_rate: 219.18
+      n_day_rate: 3
       hourly_rate: 0
       n_hourly_rate: 0
-    # capex: 3000000
   cab:
     name: Cable Laying Vessel
     equipment_rate: 75000
     capability: CAB
-    speed: 25.93  # 14 knots
+    speed: 25.93
     strategy: requests
     strategy_threshold: 1
     max_windspeed_transport: 99
@@ -524,15 +452,15 @@ vessels:
     crew_transfer_time: 0.25
     n_crews: 1
     crew:
-      day_rate: 219.18  # 80K/yr / 365 days
-      n_day_rate: 10  # N technicians for all array cable tasks
+      day_rate: 219.18
+      n_day_rate: 10
       hourly_rate: 0
       n_hourly_rate: 0
   dsv:
     name: Diving Support Vessel
     equipment_rate: 75000
     capability: DSV
-    speed: 29.63  # 16 knots
+    speed: 29.63
     strategy: requests
     max_windspeed_transport: 99
     max_windspeed_repair: 99
@@ -546,21 +474,21 @@ vessels:
     crew_transfer_time: 0.25
     n_crews: 1
     crew:
-      day_rate: 219.18  # 80K/yr / 365 days
-      n_day_rate: 10  # N technicians for all DSV tasks
+      day_rate: 219.18
+      n_day_rate: 10
       hourly_rate: 0
       n_hourly_rate: 0
   ahv:
     name: Anchor Handling Tug
-    charter_days: 3  # needs to be here, but doesn't do anything
-    equipment_rate: 66000  # AHV (55000) + Chartered CTV (11000)
+    charter_days: 3
+    equipment_rate: 66000
     strategy: requests
-    strategy_threshold: 1  # needs to be here, but doesn't do anything
+    strategy_threshold: 1
     onsite: false
     capability: AHV
-    speed: 24.08  # 13 knots
+    speed: 24.08
     tow_speed: 9.26
-    mobilization_cost: 530000  # AHV (500000) + Chartered CTV (30000)
+    mobilization_cost: 530000
     mobilization_days: 20
     max_windspeed_transport: 20
     max_windspeed_repair: 20
@@ -569,18 +497,18 @@ vessels:
     workday_start: 0
     workday_end: 24
     crew_transfer_time: 0.25
-    port_distance: 0  # will get automatically set from the port configuration if not provided
+    port_distance: 0
     n_crews: 1
     crew:
-      day_rate: 219.18  # 80K/yr / 365 days
-      n_day_rate: 10  # N technicians for all AHV jobs
+      day_rate: 219.18
+      n_day_rate: 10
       hourly_rate: 0
       n_hourly_rate: 0
   hlv:
     name: Heavy Lift Vessel
     equipment_rate: 290000
     capability: LCN
-    speed: 20.37  # 11 knots
+    speed: 20.37
     strategy: requests
     strategy_threshold: 1
     max_windspeed_transport: 10
@@ -596,7 +524,7 @@ vessels:
     crew_transfer_time: 0.25
     n_crews: 1
     crew:
-      day_rate: 219.18  # 80K/yr / 365 days
-      n_day_rate: 5  # Most tasks are 3 or 4, but some larger ones are 8, 10, and 21
+      day_rate: 219.18
+      n_day_rate: 5
       hourly_rate: 0
       n_hourly_rate: 0

--- a/library/corewind/substations/corewind_substation.yaml
+++ b/library/corewind/substations/corewind_substation.yaml
@@ -1,34 +1,28 @@
 capacity_kw: 600
-capex_kw: 120  # 120,000 EUR/MW; https://guidetoanoffshorewindfarm.com/wind-farm-costs
+capex_kw: 120
 transformer:
   name: transformer
   maintenance:
-    -
-      description: oss annual inspection
-      time: 24
-      materials: 500
-      service_equipment: CTV
-      frequency: 365
-      level: 1
-    # n_technicians: 4
+  - description: oss annual inspection
+    time: 24
+    materials: 500
+    service_equipment: CTV
+    frequency: 365
+    level: 1
   failures:
-    2:
-      scale: 5
-      shape: 1
-      time: 12
-      materials: 2000
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 2
-      description: oss minor repair
-      # n_technicians: 2
-    4:
-      scale: 100
-      shape: 1
-      time: 60
-      materials: 100000
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 4
-      description: oss major repair
-      # n_technicians: 5
+  - scale: 5
+    shape: 1
+    time: 12
+    materials: 2000
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 2
+    description: oss minor repair
+  - scale: 100
+    shape: 1
+    time: 60
+    materials: 100000
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 4
+    description: oss major repair

--- a/library/corewind/turbines/corewind_15MW.yaml
+++ b/library/corewind/turbines/corewind_15MW.yaml
@@ -12,68 +12,56 @@ electrical_system:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 1.859
-      shape: 1
-      time: 14
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 1
-      description: power converter minor repair
-      # n_technicians: 2
-    2:
-      scale: 2.793
-      shape: 1
-      time: 10
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 2
-      description: power electrical system minor repair
-      # n_technicians: 2
-    3:
-      scale: 2.959
-      shape: 1
-      time: 28
-      materials: 7000
-      service_equipment: LCN
-      operation_reduction: 0.0
-      level: 3
-      description: power converter major repair
-      # n_technicians: 3
-    4:
-      scale: 62.5
-      shape: 1
-      time: 28
-      materials: 5000
-      service_equipment: LCN
-      operation_reduction: 0.0
-      level: 4
-      description: power electrical system major repair
-      # n_technicians: 3
-    5:
-      scale: 12.99
-      shape: 1
-      time: 170
-      materials: 55000
-      service_equipment: LCN
-      operation_reduction: 0
-      replacement: true
-      level: 5
-      description: power converter replacement
-      # n_technicians: 4
-    6:
-      scale: 500
-      shape: 1
-      time: 54
-      materials: 50000
-      service_equipment: LCN
-      operation_reduction: 0
-      replacement: true
-      level: 6
-      description: power electrical system major replacement
-      # n_technicians: 4
+  - scale: 1.859
+    shape: 1
+    time: 14
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 1
+    description: power converter minor repair
+  - scale: 2.793
+    shape: 1
+    time: 10
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 2
+    description: power electrical system minor repair
+  - scale: 2.959
+    shape: 1
+    time: 28
+    materials: 7000
+    service_equipment: LCN
+    operation_reduction: 0.0
+    level: 3
+    description: power converter major repair
+  - scale: 62.5
+    shape: 1
+    time: 28
+    materials: 5000
+    service_equipment: LCN
+    operation_reduction: 0.0
+    level: 4
+    description: power electrical system major repair
+  - scale: 12.99
+    shape: 1
+    time: 170
+    materials: 55000
+    service_equipment: LCN
+    operation_reduction: 0
+    replacement: true
+    level: 5
+    description: power converter replacement
+  - scale: 500
+    shape: 1
+    time: 54
+    materials: 50000
+    service_equipment: LCN
+    operation_reduction: 0
+    replacement: true
+    level: 6
+    description: power electrical system major replacement
 hydraulic_system:
   name: hydraulic_system
   maintenance:
@@ -83,47 +71,39 @@ hydraulic_system:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 1.214
-      shape: 1
-      time: 18
-      materials: 500
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: minor pitch system repair
-      # n_technicians: 2
-    2:
-      scale: 100
-      shape: 1
-      time: 8
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 2
-      description: minor ballast pump repair
-      # n_technicians: 2
-    3:
-      scale: 5.587
-      shape: 1
-      time: 38
-      materials: 1900
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 3
-      description: major pitch system repair
-      # n_technicians: 3
-    5:
-      scale: 1000
-      shape: 1
-      time: 75
-      materials: 14000
-      service_equipment: LCN
-      operation_reduction: 0
-      replacement: true
-      level: 5
-      description: major pitch system replacement
-      # n_technicians: 4
+  - scale: 1.214
+    shape: 1
+    time: 18
+    materials: 500
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: minor pitch system repair
+  - scale: 100
+    shape: 1
+    time: 8
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 2
+    description: minor ballast pump repair
+  - scale: 5.587
+    shape: 1
+    time: 38
+    materials: 1900
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 3
+    description: major pitch system repair
+  - scale: 1000
+    shape: 1
+    time: 75
+    materials: 14000
+    service_equipment: LCN
+    operation_reduction: 0
+    replacement: true
+    level: 5
+    description: major pitch system replacement
 yaw_system:
   name: yaw_system
   maintenance:
@@ -133,37 +113,31 @@ yaw_system:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 6.173
-      shape: 1
-      time: 10
-      materials: 500
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: yaw system minor repair
-      # n_technicians: 2
-    3:
-      scale: 166.7
-      shape: 1
-      time: 40
-      materials: 3000
-      service_equipment: LCN
-      operation_reduction: 0.0
-      level: 3
-      description: yaw system major repair
-      # n_technicians: 3
-    5:
-      scale: 1000
-      shape: 1
-      time: 147
-      materials: 12500
-      service_equipment: LCN
-      operation_reduction: 0
-      replacement: true
-      level: 5
-      description: yaw system major replacement
-      # n_technicians: 5
+  - scale: 6.173
+    shape: 1
+    time: 10
+    materials: 500
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: yaw system minor repair
+  - scale: 166.7
+    shape: 1
+    time: 40
+    materials: 3000
+    service_equipment: LCN
+    operation_reduction: 0.0
+    level: 3
+    description: yaw system major repair
+  - scale: 1000
+    shape: 1
+    time: 147
+    materials: 12500
+    service_equipment: LCN
+    operation_reduction: 0
+    replacement: true
+    level: 5
+    description: yaw system major replacement
 rotor_blades:
   name: rotor_blades
   maintenance:
@@ -173,37 +147,31 @@ rotor_blades:
     service_equipment: CTV
     frequency: 0
   failures:
-    2:
-      scale: 2.193
-      shape: 1
-      time: 18
-      materials: 6000
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 2
-      description: blades minor repair
-      # n_technicians: 2
-    4:
-      scale: 100
-      shape: 1
-      time: 42
-      materials: 51732
-      service_equipment: LCN
-      operation_reduction: 0.0
-      level: 4
-      description: blades major repair
-      # n_technicians: 3
-    6:
-      scale: 1000
-      shape: 1
-      time: 864
-      materials: 534000
-      service_equipment: LCN
-      operation_reduction: 0
-      replacement: true
-      level: 6
-      description: blades major replacement
-      # n_technicians: 21
+  - scale: 2.193
+    shape: 1
+    time: 18
+    materials: 6000
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 2
+    description: blades minor repair
+  - scale: 100
+    shape: 1
+    time: 42
+    materials: 51732
+    service_equipment: LCN
+    operation_reduction: 0.0
+    level: 4
+    description: blades major repair
+  - scale: 1000
+    shape: 1
+    time: 864
+    materials: 534000
+    service_equipment: LCN
+    operation_reduction: 0
+    replacement: true
+    level: 6
+    description: blades major replacement
 generator:
   name: generator
   maintenance:
@@ -212,39 +180,32 @@ generator:
     materials: 1500
     service_equipment: CTV
     frequency: 365
-    # n_technicians: 3
   failures:
-    2:
-      scale: 1.832
-      shape: 1
-      time: 13
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 2
-      description: direct drive generator minor repair
-      # n_technicians: 2
-    4:
-      scale: 33.333
-      shape: 1
-      time: 49
-      materials: 14340
-      service_equipment: LCN
-      operation_reduction: 0.0
-      level: 4
-      description: direct drive generator major repair
-      # n_technicians: 3
-    6:
-      scale: 111.1111
-      shape: 1
-      time: 244
-      materials: 236500
-      service_equipment: LCN
-      operation_reduction: 0
-      replacement: true
-      level: 6
-      description: direct drive generator major replacement
-      # n_technicians: 8
+  - scale: 1.832
+    shape: 1
+    time: 13
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 2
+    description: direct drive generator minor repair
+  - scale: 33.333
+    shape: 1
+    time: 49
+    materials: 14340
+    service_equipment: LCN
+    operation_reduction: 0.0
+    level: 4
+    description: direct drive generator major repair
+  - scale: 111.1111
+    shape: 1
+    time: 244
+    materials: 236500
+    service_equipment: LCN
+    operation_reduction: 0
+    replacement: true
+    level: 6
+    description: direct drive generator major replacement
 supporting_structure:
   name: supporting_structure
   maintenance:
@@ -253,77 +214,63 @@ supporting_structure:
     materials: 600
     service_equipment: CTV
     frequency: 365
-    # n_technicians: 4
   - description: structural subsea inspection
     time: 6
     materials: 500
     service_equipment: DSV
     frequency: 730
-    # n_technicians: 5
   failures:
-    1:
-      scale: 8.33
-      shape: 1
-      time: 40
-      materials: 1500
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: marine growth removal
-      # n_technicians: 5
-    2:
-      scale: 66.67
-      shape: 1
-      time: 240
-      materials: 75000
-      service_equipment: AHV
-      operation_reduction: 0
-      level: 2
-      description: major anchor repair
-      # n_technicians: 10
-    3:
-      scale: 66.67
-      shape: 1
-      time: 240
-      materials: 20000
-      service_equipment: AHV
-      operation_reduction: 0
-      level: 3
-      description: mooring line major repair
-      # n_technicians: 10
-    4:
-      scale: 80
-      shape: 1
-      time: 360
-      materials: 512000
-      service_equipment: AHV
-      operation_reduction: 0
-      replacement: true
-      level: 4
-      description: anchor replacement
-      # n_technicians: 10
-    5:
-      scale: 80
-      shape: 1
-      time: 360
-      materials: 135000
-      service_equipment: AHV
-      operation_reduction: 0
-      replacement: true
-      level: 5
-      description: mooring line replacement
-      # n_technicians: 10
-    6:
-      scale: 30.3
-      shape: 1
-      time: 40
-      materials: 100000
-      service_equipment: CTV
-      operation_reduction: 0
-      replacement: true
-      level: 6
-      description: buoyancy module replacement
-      # n_technicians: 5
+  - scale: 8.33
+    shape: 1
+    time: 40
+    materials: 1500
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: marine growth removal
+  - scale: 66.67
+    shape: 1
+    time: 240
+    materials: 75000
+    service_equipment: AHV
+    operation_reduction: 0
+    level: 2
+    description: major anchor repair
+  - scale: 66.67
+    shape: 1
+    time: 240
+    materials: 20000
+    service_equipment: AHV
+    operation_reduction: 0
+    level: 3
+    description: mooring line major repair
+  - scale: 80
+    shape: 1
+    time: 360
+    materials: 512000
+    service_equipment: AHV
+    operation_reduction: 0
+    replacement: true
+    level: 4
+    description: anchor replacement
+  - scale: 80
+    shape: 1
+    time: 360
+    materials: 135000
+    service_equipment: AHV
+    operation_reduction: 0
+    replacement: true
+    level: 5
+    description: mooring line replacement
+  - scale: 30.3
+    shape: 1
+    time: 40
+    materials: 100000
+    service_equipment: CTV
+    operation_reduction: 0
+    replacement: true
+    level: 6
+    description: buoyancy module replacement
 drive_train:
   name: drive_train
   maintenance:
@@ -333,34 +280,28 @@ drive_train:
     service_equipment: CTV
     frequency: 0
   failures:
-    2:
-      scale: 4.329
-      shape: 1
-      time: 10
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 2
-      description: main shaft minor repair
-      # n_technicians: 2
-    4:
-      scale: 38.462
-      shape: 1
-      time: 36
-      materials: 14000
-      service_equipment: LCN
-      operation_reduction: 0
-      level: 4
-      description: main shaft major repair
-      # n_technicians: 3
-    6:
-      scale: 111.111
-      shape: 1
-      time: 144
-      materials: 232000
-      service_equipment: LCN
-      operation_reduction: 0
-      replacement: true
-      level: 6
-      description: main shaft replacement
-      # n_technicians: 5
+  - scale: 4.329
+    shape: 1
+    time: 10
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 2
+    description: main shaft minor repair
+  - scale: 38.462
+    shape: 1
+    time: 36
+    materials: 14000
+    service_equipment: LCN
+    operation_reduction: 0
+    level: 4
+    description: main shaft major repair
+  - scale: 111.111
+    shape: 1
+    time: 144
+    materials: 232000
+    service_equipment: LCN
+    operation_reduction: 0
+    replacement: true
+    level: 6
+    description: main shaft replacement

--- a/library/corewind/turbines/corewind_15MW_ttp.yaml
+++ b/library/corewind/turbines/corewind_15MW_ttp.yaml
@@ -12,68 +12,56 @@ electrical_system:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 1.859
-      shape: 1
-      time: 14
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 1
-      description: power converter minor repair
-      # n_technicians: 2
-    2:
-      scale: 2.793
-      shape: 1
-      time: 10
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 2
-      description: power electrical system minor repair
-      # n_technicians: 2
-    3:
-      scale: 2.959
-      shape: 1
-      time: 28
-      materials: 7000
-      service_equipment: TOW
-      operation_reduction: 0.0
-      level: 3
-      description: power converter major repair
-      # n_technicians: 3
-    4:
-      scale: 62.5
-      shape: 1
-      time: 28
-      materials: 5000
-      service_equipment: TOW
-      operation_reduction: 0.0
-      level: 4
-      description: power electrical system major repair
-      # n_technicians: 3
-    5:
-      scale: 12.99
-      shape: 1
-      time: 170
-      materials: 55000
-      service_equipment: TOW
-      operation_reduction: 0
-      replacement: true
-      level: 5
-      description: power converter replacement
-      # n_technicians: 4
-    6:
-      scale: 500
-      shape: 1
-      time: 54
-      materials: 50000
-      service_equipment: TOW
-      operation_reduction: 0
-      replacement: true
-      level: 6
-      description: power electrical system major replacement
-      # n_technicians: 4
+  - scale: 1.859
+    shape: 1
+    time: 14
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 1
+    description: power converter minor repair
+  - scale: 2.793
+    shape: 1
+    time: 10
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 2
+    description: power electrical system minor repair
+  - scale: 2.959
+    shape: 1
+    time: 28
+    materials: 7000
+    service_equipment: TOW
+    operation_reduction: 0.0
+    level: 3
+    description: power converter major repair
+  - scale: 62.5
+    shape: 1
+    time: 28
+    materials: 5000
+    service_equipment: TOW
+    operation_reduction: 0.0
+    level: 4
+    description: power electrical system major repair
+  - scale: 12.99
+    shape: 1
+    time: 170
+    materials: 55000
+    service_equipment: TOW
+    operation_reduction: 0
+    replacement: true
+    level: 5
+    description: power converter replacement
+  - scale: 500
+    shape: 1
+    time: 54
+    materials: 50000
+    service_equipment: TOW
+    operation_reduction: 0
+    replacement: true
+    level: 6
+    description: power electrical system major replacement
 hydraulic_system:
   name: hydraulic_system
   maintenance:
@@ -83,47 +71,39 @@ hydraulic_system:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 1.214
-      shape: 1
-      time: 18
-      materials: 500
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: minor pitch system repair
-      # n_technicians: 2
-    2:
-      scale: 100
-      shape: 1
-      time: 8
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 2
-      description: minor ballast pump repair
-      # n_technicians: 2
-    3:
-      scale: 5.587
-      shape: 1
-      time: 38
-      materials: 1900
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 3
-      description: major pitch system repair
-      # n_technicians: 3
-    5:
-      scale: 1000
-      shape: 1
-      time: 75
-      materials: 14000
-      service_equipment: TOW
-      operation_reduction: 0
-      replacement: true
-      level: 5
-      description: major pitch system replacement
-      # n_technicians: 4
+  - scale: 1.214
+    shape: 1
+    time: 18
+    materials: 500
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: minor pitch system repair
+  - scale: 100
+    shape: 1
+    time: 8
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 2
+    description: minor ballast pump repair
+  - scale: 5.587
+    shape: 1
+    time: 38
+    materials: 1900
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 3
+    description: major pitch system repair
+  - scale: 1000
+    shape: 1
+    time: 75
+    materials: 14000
+    service_equipment: TOW
+    operation_reduction: 0
+    replacement: true
+    level: 5
+    description: major pitch system replacement
 yaw_system:
   name: yaw_system
   maintenance:
@@ -133,37 +113,31 @@ yaw_system:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 6.173
-      shape: 1
-      time: 10
-      materials: 500
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: yaw system minor repair
-      # n_technicians: 2
-    3:
-      scale: 166.7
-      shape: 1
-      time: 40
-      materials: 3000
-      service_equipment: TOW
-      operation_reduction: 0.0
-      level: 3
-      description: yaw system major repair
-      # n_technicians: 3
-    5:
-      scale: 1000
-      shape: 1
-      time: 147
-      materials: 12500
-      service_equipment: TOW
-      operation_reduction: 0
-      replacement: true
-      level: 5
-      description: yaw system major replacement
-      # n_technicians: 5
+  - scale: 6.173
+    shape: 1
+    time: 10
+    materials: 500
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: yaw system minor repair
+  - scale: 166.7
+    shape: 1
+    time: 40
+    materials: 3000
+    service_equipment: TOW
+    operation_reduction: 0.0
+    level: 3
+    description: yaw system major repair
+  - scale: 1000
+    shape: 1
+    time: 147
+    materials: 12500
+    service_equipment: TOW
+    operation_reduction: 0
+    replacement: true
+    level: 5
+    description: yaw system major replacement
 rotor_blades:
   name: rotor_blades
   maintenance:
@@ -173,37 +147,31 @@ rotor_blades:
     service_equipment: CTV
     frequency: 0
   failures:
-    2:
-      scale: 2.193
-      shape: 1
-      time: 18
-      materials: 6000
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 2
-      description: blades minor repair
-      # n_technicians: 2
-    4:
-      scale: 100
-      shape: 1
-      time: 42
-      materials: 51732
-      service_equipment: TOW
-      operation_reduction: 0.0
-      level: 4
-      description: blades major repair
-      # n_technicians: 3
-    6:
-      scale: 1000
-      shape: 1
-      time: 864
-      materials: 534000
-      service_equipment: TOW
-      operation_reduction: 0
-      replacement: true
-      level: 6
-      description: blades major replacement
-      # n_technicians: 21
+  - scale: 2.193
+    shape: 1
+    time: 18
+    materials: 6000
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 2
+    description: blades minor repair
+  - scale: 100
+    shape: 1
+    time: 42
+    materials: 51732
+    service_equipment: TOW
+    operation_reduction: 0.0
+    level: 4
+    description: blades major repair
+  - scale: 1000
+    shape: 1
+    time: 864
+    materials: 534000
+    service_equipment: TOW
+    operation_reduction: 0
+    replacement: true
+    level: 6
+    description: blades major replacement
 generator:
   name: generator
   maintenance:
@@ -212,39 +180,32 @@ generator:
     materials: 1500
     service_equipment: CTV
     frequency: 365
-    # n_technicians: 3
   failures:
-    2:
-      scale: 1.832
-      shape: 1
-      time: 13
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 2
-      description: direct drive generator minor repair
-      # n_technicians: 2
-    4:
-      scale: 33.333
-      shape: 1
-      time: 49
-      materials: 14340
-      service_equipment: TOW
-      operation_reduction: 0.0
-      level: 4
-      description: direct drive generator major repair
-      # n_technicians: 3
-    6:
-      scale: 111.1111
-      shape: 1
-      time: 244
-      materials: 236500
-      service_equipment: TOW
-      operation_reduction: 0
-      replacement: true
-      level: 6
-      description: direct drive generator major replacement
-      # n_technicians: 8
+  - scale: 1.832
+    shape: 1
+    time: 13
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 2
+    description: direct drive generator minor repair
+  - scale: 33.333
+    shape: 1
+    time: 49
+    materials: 14340
+    service_equipment: TOW
+    operation_reduction: 0.0
+    level: 4
+    description: direct drive generator major repair
+  - scale: 111.1111
+    shape: 1
+    time: 244
+    materials: 236500
+    service_equipment: TOW
+    operation_reduction: 0
+    replacement: true
+    level: 6
+    description: direct drive generator major replacement
 supporting_structure:
   name: supporting_structure
   maintenance:
@@ -253,77 +214,63 @@ supporting_structure:
     materials: 600
     service_equipment: CTV
     frequency: 365
-    # n_technicians: 4
   - description: structural subsea inspection
     time: 6
     materials: 500
     service_equipment: DSV
     frequency: 730
-    # n_technicians: 5
   failures:
-    1:
-      scale: 8.33
-      shape: 1
-      time: 40
-      materials: 1500
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: marine growth removal
-      # n_technicians: 5
-    2:
-      scale: 66.67
-      shape: 1
-      time: 240
-      materials: 75000
-      service_equipment: AHV
-      operation_reduction: 0
-      level: 2
-      description: major anchor repair
-      # n_technicians: 10
-    3:
-      scale: 66.67
-      shape: 1
-      time: 240
-      materials: 20000
-      service_equipment: AHV
-      operation_reduction: 0
-      level: 3
-      description: mooring line major repair
-      # n_technicians: 10
-    4:
-      scale: 80
-      shape: 1
-      time: 360
-      materials: 512000
-      service_equipment: AHV
-      operation_reduction: 0
-      replacement: true
-      level: 4
-      description: anchor replacement
-      # n_technicians: 10
-    5:
-      scale: 80
-      shape: 1
-      time: 360
-      materials: 135000
-      service_equipment: AHV
-      operation_reduction: 0
-      replacement: true
-      level: 5
-      description: mooring line replacement
-      # n_technicians: 10
-    6:
-      scale: 30.3
-      shape: 1
-      time: 40
-      materials: 100000
-      service_equipment: CTV
-      operation_reduction: 0
-      replacement: true
-      level: 6
-      description: buoyancy module replacement
-      # n_technicians: 5
+  - scale: 8.33
+    shape: 1
+    time: 40
+    materials: 1500
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: marine growth removal
+  - scale: 66.67
+    shape: 1
+    time: 240
+    materials: 75000
+    service_equipment: AHV
+    operation_reduction: 0
+    level: 2
+    description: major anchor repair
+  - scale: 66.67
+    shape: 1
+    time: 240
+    materials: 20000
+    service_equipment: AHV
+    operation_reduction: 0
+    level: 3
+    description: mooring line major repair
+  - scale: 80
+    shape: 1
+    time: 360
+    materials: 512000
+    service_equipment: AHV
+    operation_reduction: 0
+    replacement: true
+    level: 4
+    description: anchor replacement
+  - scale: 80
+    shape: 1
+    time: 360
+    materials: 135000
+    service_equipment: AHV
+    operation_reduction: 0
+    replacement: true
+    level: 5
+    description: mooring line replacement
+  - scale: 30.3
+    shape: 1
+    time: 40
+    materials: 100000
+    service_equipment: CTV
+    operation_reduction: 0
+    replacement: true
+    level: 6
+    description: buoyancy module replacement
 drive_train:
   name: drive_train
   maintenance:
@@ -333,34 +280,28 @@ drive_train:
     service_equipment: CTV
     frequency: 0
   failures:
-    2:
-      scale: 4.329
-      shape: 1
-      time: 10
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 2
-      description: main shaft minor repair
-      # n_technicians: 2
-    4:
-      scale: 38.462
-      shape: 1
-      time: 36
-      materials: 14000
-      service_equipment: TOW
-      operation_reduction: 0
-      level: 4
-      description: main shaft major repair
-      # n_technicians: 3
-    6:
-      scale: 111.111
-      shape: 1
-      time: 144
-      materials: 232000
-      service_equipment: TOW
-      operation_reduction: 0
-      replacement: true
-      level: 6
-      description: main shaft replacement
-      # n_technicians: 5
+  - scale: 4.329
+    shape: 1
+    time: 10
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 2
+    description: main shaft minor repair
+  - scale: 38.462
+    shape: 1
+    time: 36
+    materials: 14000
+    service_equipment: TOW
+    operation_reduction: 0
+    level: 4
+    description: main shaft major repair
+  - scale: 111.111
+    shape: 1
+    time: 144
+    materials: 232000
+    service_equipment: TOW
+    operation_reduction: 0
+    replacement: true
+    level: 6
+    description: main shaft replacement

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,8 +96,8 @@ GENERATOR_SUBASSEMBLY = {
             "system_value": 39000000,
         }
     ],
-    "failures": {
-        1: {
+    "failures": [
+        {
             "scale": 0.1333,
             "shape": 1,
             "time": 3,
@@ -108,7 +108,7 @@ GENERATOR_SUBASSEMBLY = {
             "description": "manual reset",
             "system_value": 39000000,
         },
-        2: {
+        {
             "scale": 0.3333,
             "shape": 1,
             "time": 7.5,
@@ -119,7 +119,7 @@ GENERATOR_SUBASSEMBLY = {
             "description": "minor repair",
             "system_value": 39000000,
         },
-        3: {
+        {
             "scale": 3.6363,
             "shape": 1,
             "time": 22,
@@ -130,7 +130,7 @@ GENERATOR_SUBASSEMBLY = {
             "description": "medium repair",
             "system_value": 39000000,
         },
-        4: {
+        {
             "scale": 25,
             "shape": 1,
             "time": 26,
@@ -141,7 +141,7 @@ GENERATOR_SUBASSEMBLY = {
             "description": "major repair",
             "system_value": 39000000,
         },
-        5: {
+        {
             "scale": 12.5,
             "shape": 1,
             "time": 52,
@@ -152,7 +152,7 @@ GENERATOR_SUBASSEMBLY = {
             "description": "major replacement",
             "system_value": 39000000,
         },
-    },
+    ],
     "rng": RNG,
 }
 

--- a/tests/library/cables/array_33kv_240mm.yaml
+++ b/tests/library/cables/array_33kv_240mm.yaml
@@ -1,18 +1,17 @@
 name: array cable
 maintenance:
-  -
-    description: n/a
-    time: 0
-    materials: 0
-    service_equipment: CTV
-    frequency: 0
+- description: n/a
+  time: 0
+  materials: 0
+  service_equipment: CTV
+  frequency: 0
 failures:
-  5:
-    scale: 2500
-    shape: 1
-    time: 32
-    materials: 350000
-    operation_reduction: 1
-    service_equipment: [CAB]
-    level: 5
-    description: cable replacement
+- scale: 2500
+  shape: 1
+  time: 32
+  materials: 350000
+  operation_reduction: 1
+  service_equipment:
+  - CAB
+  level: 5
+  description: cable replacement

--- a/tests/library/cables/array_33kv_630mm.yaml
+++ b/tests/library/cables/array_33kv_630mm.yaml
@@ -1,18 +1,17 @@
 name: array cable
 maintenance:
-  -
-    description: n/a
-    time: 0
-    materials: 0
-    service_equipment: CTV
-    frequency: 0
+- description: n/a
+  time: 0
+  materials: 0
+  service_equipment: CTV
+  frequency: 0
 failures:
-  5:
-    scale: 2500
-    shape: 1
-    time: 32
-    materials: 350000
-    operation_reduction: 1
-    service_equipment: [CAB]
-    level: 5
-    description: cable replacement
+- scale: 2500
+  shape: 1
+  time: 32
+  materials: 350000
+  operation_reduction: 1
+  service_equipment:
+  - CAB
+  level: 5
+  description: cable replacement

--- a/tests/library/cables/array_fast_fail.yaml
+++ b/tests/library/cables/array_fast_fail.yaml
@@ -1,18 +1,17 @@
 name: array cable
 maintenance:
-  -
-    description: n/a
-    time: 0
-    materials: 0
-    service_equipment: CTV
-    frequency: 0
+- description: n/a
+  time: 0
+  materials: 0
+  service_equipment: CTV
+  frequency: 0
 failures:
-  5:
-    scale: 0.001
-    shape: 1
-    time: 32
-    materials: 350000
-    operation_reduction: 1
-    service_equipment: [CAB]
-    level: 5
-    description: cable replacement
+- scale: 0.001
+  shape: 1
+  time: 32
+  materials: 350000
+  operation_reduction: 1
+  service_equipment:
+  - CAB
+  level: 5
+  description: cable replacement

--- a/tests/library/cables/array_no_fail.yaml
+++ b/tests/library/cables/array_no_fail.yaml
@@ -1,18 +1,17 @@
 name: array cable
 maintenance:
-  -
-    description: n/a
-    time: 0
-    materials: 0
-    service_equipment: CTV
-    frequency: 0
+- description: n/a
+  time: 0
+  materials: 0
+  service_equipment: CTV
+  frequency: 0
 failures:
-  1:
-    scale: 0
-    shape: 0
-    time: 0
-    materials: 0
-    operation_reduction: 0
-    service_equipment: [CAB]
-    level: 0
-    description: na
+- scale: 0
+  shape: 0
+  time: 0
+  materials: 0
+  operation_reduction: 0
+  service_equipment:
+  - CAB
+  level: 0
+  description: na

--- a/tests/library/cables/export.yaml
+++ b/tests/library/cables/export.yaml
@@ -6,12 +6,11 @@ maintenance:
   service_equipment: CTV
   frequency: 0
 failures:
-  1:
-    scale: 0
-    shape: 0
-    time: 0
-    materials: 0
-    service_equipment: CTV
-    operation_reduction: 0.0
-    level: 1
-    description: na
+- scale: 0
+  shape: 0
+  time: 0
+  materials: 0
+  service_equipment: CTV
+  operation_reduction: 0.0
+  level: 1
+  description: na

--- a/tests/library/substations/offshore_substation.yaml
+++ b/tests/library/substations/offshore_substation.yaml
@@ -3,19 +3,18 @@ capex_kw: 0
 transformer:
   name: transformer
   maintenance:
-    -
-      description: n/a
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      frequency: 0
+  - description: n/a
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: [CTV]
-      operation_reduction: 0
-      level: 1
-      description: n/a
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment:
+    - CTV
+    operation_reduction: 0
+    level: 1
+    description: n/a

--- a/tests/library/turbines/vestas_v90.yaml
+++ b/tests/library/turbines/vestas_v90.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
   bin_width: 0.5
@@ -12,15 +12,14 @@ electrical_system:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: n/a
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: n/a
 electronic_control:
   name: electronic_control
   maintenance:
@@ -30,15 +29,14 @@ electronic_control:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: n/a
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: n/a
 sensors:
   name: sensors
   maintenance:
@@ -48,15 +46,14 @@ sensors:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: n/a
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: n/a
 hydraulic_system:
   name: hydraulic_system
   maintenance:
@@ -66,15 +63,14 @@ hydraulic_system:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: n/a
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: n/a
 yaw_system:
   name: yaw_system
   maintenance:
@@ -84,15 +80,14 @@ yaw_system:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: n/a
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: n/a
 rotor_blades:
   name: rotor_blades
   maintenance:
@@ -102,15 +97,14 @@ rotor_blades:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: n/a
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: n/a
 mechanical_brake:
   name: mechanical_brake
   maintenance:
@@ -120,15 +114,14 @@ mechanical_brake:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: n/a
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: n/a
 rotor_hub:
   name: rotor_hub
   maintenance:
@@ -138,15 +131,14 @@ rotor_hub:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: n/a
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: n/a
 gearbox:
   name: gearbox
   maintenance:
@@ -156,15 +148,14 @@ gearbox:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: n/a
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: n/a
 generator:
   name: generator
   maintenance:
@@ -174,51 +165,46 @@ generator:
     service_equipment: CTV
     frequency: 365
   failures:
-    1:
-      scale: 0.1333
-      shape: 1
-      time: 3
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0.3333
-      shape: 1
-      time: 7.5
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 3.6363
-      shape: 1
-      time: 22
-      materials: 18500
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 25
-      shape: 1
-      time: 26
-      materials: 73500
-      service_equipment: SCN
-      operation_reduction: 0.0
-      level: 4
-      description: major repair
-    5:
-      scale: 12.5
-      shape: 1
-      time: 52
-      materials: 334500
-      service_equipment: LCN
-      operation_reduction: 1.0
-      level: 5
-      description: major replacement
+  - scale: 0.1333
+    shape: 1
+    time: 3
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 1
+    description: manual reset
+  - scale: 0.3333
+    shape: 1
+    time: 7.5
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 2
+    description: minor repair
+  - scale: 3.6363
+    shape: 1
+    time: 22
+    materials: 18500
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 3
+    description: medium repair
+  - scale: 25
+    shape: 1
+    time: 26
+    materials: 73500
+    service_equipment: SCN
+    operation_reduction: 0.0
+    level: 4
+    description: major repair
+  - scale: 12.5
+    shape: 1
+    time: 52
+    materials: 334500
+    service_equipment: LCN
+    operation_reduction: 1.0
+    level: 5
+    description: major replacement
 supporting_structure:
   name: supporting_structure
   maintenance:
@@ -228,15 +214,14 @@ supporting_structure:
     service_equipment: CTV
     frequency: 0
   failures:
-    3:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 3
-      description: n/a
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 3
+    description: n/a
 drive_train:
   name: drive_train
   maintenance:
@@ -246,12 +231,11 @@ drive_train:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: n/a
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: n/a

--- a/tests/library/turbines/vestas_v90_no_subassemblies.yaml
+++ b/tests/library/turbines/vestas_v90_no_subassemblies.yaml
@@ -1,2 +1,2 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300

--- a/tests/library/turbines/vestas_v90_single_subassembly.yaml
+++ b/tests/library/turbines/vestas_v90_single_subassembly.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 generator:
   name: generator
   maintenance:
@@ -14,48 +14,43 @@ generator:
     service_equipment: CTV
     frequency: 10
   failures:
-    1:
-      scale: 0.1333
-      shape: 1
-      time: 3
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0.3333
-      shape: 1
-      time: 7.5
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 3.6363
-      shape: 1
-      time: 22
-      materials: 18500
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 25
-      shape: 1
-      time: 26
-      materials: 73500
-      service_equipment: SCN
-      operation_reduction: 0.0
-      level: 4
-      description: major repair
-    5:
-      scale: 12.5
-      shape: 1
-      time: 52
-      materials: 334500
-      service_equipment: LCN
-      operation_reduction: 1.0
-      level: 5
-      description: major replacement
+  - scale: 0.1333
+    shape: 1
+    time: 3
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 1
+    description: manual reset
+  - scale: 0.3333
+    shape: 1
+    time: 7.5
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 2
+    description: minor repair
+  - scale: 3.6363
+    shape: 1
+    time: 22
+    materials: 18500
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 3
+    description: medium repair
+  - scale: 25
+    shape: 1
+    time: 26
+    materials: 73500
+    service_equipment: SCN
+    operation_reduction: 0.0
+    level: 4
+    description: major repair
+  - scale: 12.5
+    shape: 1
+    time: 52
+    materials: 334500
+    service_equipment: LCN
+    operation_reduction: 1.0
+    level: 5
+    description: major replacement

--- a/tests/library/turbines/vestas_v90_test_simulation.yaml
+++ b/tests/library/turbines/vestas_v90_test_simulation.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 generator:
   name: generator
   maintenance:
@@ -19,12 +19,11 @@ generator:
     service_equipment: LCN
     frequency: 50
   failures:
-    10:
-      scale: 25  # don't want to hit this
-      shape: 1
-      time: 1
-      materials: 14
-      service_equipment: LCN
-      operation_reduction: 1
-      level: 10
-      description: catastrophic failure
+  - scale: 25
+    shape: 1
+    time: 1
+    materials: 14
+    service_equipment: LCN
+    operation_reduction: 1
+    level: 10
+    description: catastrophic failure

--- a/tests/library/turbines/vestas_v90_test_timeouts.yaml
+++ b/tests/library/turbines/vestas_v90_test_timeouts.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 generator:
   name: generator
   maintenance:
@@ -9,24 +9,22 @@ generator:
     service_equipment: CTV
     frequency: 5
   failures:
-    1:
-      scale: 0.03
-      shape: 1
-      time: 1
-      materials: 14
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 1
-      description: test reset
-    10:
-      scale: 0.5
-      shape: 1
-      time: 1
-      materials: 14
-      service_equipment: CTV
-      operation_reduction: 1
-      level: 10
-      description: catastrophic failure
+  - scale: 0.03
+    shape: 1
+    time: 1
+    materials: 14
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 1
+    description: test reset
+  - scale: 0.5
+    shape: 1
+    time: 1
+    materials: 14
+    service_equipment: CTV
+    operation_reduction: 1
+    level: 10
+    description: catastrophic failure
 gearbox:
   name: gearbox
   maintenance:
@@ -36,12 +34,11 @@ gearbox:
     service_equipment: CTV
     frequency: 100
   failures:
-    1:
-      scale: 1
-      shape: 1
-      time: 1
-      materials: 14
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 1
-      description: test reset
+  - scale: 1
+    shape: 1
+    time: 1
+    materials: 14
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 1
+    description: test reset

--- a/tests/library/turbines/vestas_v90_with_gearbox.yaml
+++ b/tests/library/turbines/vestas_v90_with_gearbox.yaml
@@ -1,5 +1,5 @@
 capacity_kw: 3000
-capex_kw: 1300  # need an updated value
+capex_kw: 1300
 power_curve:
   file: vestas_v90_power_curve.csv
   bin_width: 0.5
@@ -12,15 +12,14 @@ electrical_system:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: n/a
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: n/a
 electronic_control:
   name: electronic_control
   maintenance:
@@ -30,15 +29,14 @@ electronic_control:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: n/a
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: n/a
 sensors:
   name: sensors
   maintenance:
@@ -48,15 +46,14 @@ sensors:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: n/a
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: n/a
 hydraulic_system:
   name: hydraulic_system
   maintenance:
@@ -66,15 +63,14 @@ hydraulic_system:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: n/a
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: n/a
 yaw_system:
   name: yaw_system
   maintenance:
@@ -84,15 +80,14 @@ yaw_system:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: n/a
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: n/a
 rotor_blades:
   name: rotor_blades
   maintenance:
@@ -102,15 +97,14 @@ rotor_blades:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: n/a
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: n/a
 mechanical_brake:
   name: mechanical_brake
   maintenance:
@@ -120,15 +114,14 @@ mechanical_brake:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: n/a
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: n/a
 rotor_hub:
   name: rotor_hub
   maintenance:
@@ -138,15 +131,14 @@ rotor_hub:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: n/a
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: n/a
 gearbox:
   name: gearbox
   maintenance:
@@ -156,51 +148,46 @@ gearbox:
     service_equipment: CTV
     frequency: 365
   failures:
-    1:
-      scale: 0.1333
-      shape: 1
-      time: 3
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0.3333
-      shape: 1
-      time: 7.5
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 3.6363
-      shape: 1
-      time: 22
-      materials: 18500
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 25
-      shape: 1
-      time: 26
-      materials: 73500
-      service_equipment: SCN
-      operation_reduction: 0.0
-      level: 4
-      description: major repair
-    5:
-      scale: 12.5
-      shape: 1
-      time: 52
-      materials: 334500
-      service_equipment: LCN
-      operation_reduction: 1.0
-      level: 5
-      description: major replacement
+  - scale: 0.1333
+    shape: 1
+    time: 3
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 1
+    description: manual reset
+  - scale: 0.3333
+    shape: 1
+    time: 7.5
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 2
+    description: minor repair
+  - scale: 3.6363
+    shape: 1
+    time: 22
+    materials: 18500
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 3
+    description: medium repair
+  - scale: 25
+    shape: 1
+    time: 26
+    materials: 73500
+    service_equipment: SCN
+    operation_reduction: 0.0
+    level: 4
+    description: major repair
+  - scale: 12.5
+    shape: 1
+    time: 52
+    materials: 334500
+    service_equipment: LCN
+    operation_reduction: 1.0
+    level: 5
+    description: major replacement
 generator:
   name: generator
   maintenance:
@@ -210,51 +197,46 @@ generator:
     service_equipment: CTV
     frequency: 365
   failures:
-    1:
-      scale: 0.1333
-      shape: 1
-      time: 3
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 1
-      description: manual reset
-    2:
-      scale: 0.3333
-      shape: 1
-      time: 7.5
-      materials: 1000
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 2
-      description: minor repair
-    3:
-      scale: 3.6363
-      shape: 1
-      time: 22
-      materials: 18500
-      service_equipment: CTV
-      operation_reduction: 0.0
-      level: 3
-      description: medium repair
-    4:
-      scale: 25
-      shape: 1
-      time: 26
-      materials: 73500
-      service_equipment: SCN
-      operation_reduction: 0.0
-      level: 4
-      description: major repair
-    5:
-      scale: 12.5
-      shape: 1
-      time: 52
-      materials: 334500
-      service_equipment: LCN
-      operation_reduction: 1.0
-      level: 5
-      description: major replacement
+  - scale: 0.1333
+    shape: 1
+    time: 3
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 1
+    description: manual reset
+  - scale: 0.3333
+    shape: 1
+    time: 7.5
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 2
+    description: minor repair
+  - scale: 3.6363
+    shape: 1
+    time: 22
+    materials: 18500
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 3
+    description: medium repair
+  - scale: 25
+    shape: 1
+    time: 26
+    materials: 73500
+    service_equipment: SCN
+    operation_reduction: 0.0
+    level: 4
+    description: major repair
+  - scale: 12.5
+    shape: 1
+    time: 52
+    materials: 334500
+    service_equipment: LCN
+    operation_reduction: 1.0
+    level: 5
+    description: major replacement
 supporting_structure:
   name: supporting_structure
   maintenance:
@@ -264,15 +246,14 @@ supporting_structure:
     service_equipment: CTV
     frequency: 0
   failures:
-    3:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 3
-      description: n/a
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 3
+    description: n/a
 drive_train:
   name: drive_train
   maintenance:
@@ -282,12 +263,11 @@ drive_train:
     service_equipment: CTV
     frequency: 0
   failures:
-    1:
-      scale: 0
-      shape: 0
-      time: 0
-      materials: 0
-      service_equipment: CTV
-      operation_reduction: 0
-      level: 1
-      description: n/a
+  - scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: n/a

--- a/tests/test_data_classes.py
+++ b/tests/test_data_classes.py
@@ -454,7 +454,7 @@ def test_RepairRequest():
     assert cls.system_name == request["system_name"]
     assert cls.subassembly_id == request["subassembly_id"]
     assert cls.subassembly_name == request["subassembly_name"]
-    assert cls.severity_level == 1
+    assert cls.severity_level == 2
     assert cls.cable
     assert cls.upstream_turbines == []
 

--- a/tests/test_data_classes.py
+++ b/tests/test_data_classes.py
@@ -398,17 +398,16 @@ def test_Failure():
 def test_SubassemblyData():
     """Tests the `SubassemblyData` class."""
     N_maintenance = len(GENERATOR_SUBASSEMBLY["maintenance"])
-    failure_levels = [f["level"] for f in GENERATOR_SUBASSEMBLY["failures"].values()]
+    failure_levels = [f["level"] for f in GENERATOR_SUBASSEMBLY["failures"]]
     N_failure = len(failure_levels)
 
     subassembly = SubassemblyData.from_dict(GENERATOR_SUBASSEMBLY)
     maintenance_list = [
         Maintenance.from_dict(m) for m in GENERATOR_SUBASSEMBLY["maintenance"]
     ]
-    failure_dict = {
-        level: Failure.from_dict({**f, "rng": RNG})
-        for level, f in GENERATOR_SUBASSEMBLY["failures"].items()
-    }
+    failure_list = [
+        Failure.from_dict({**f, "rng": RNG}) for f in GENERATOR_SUBASSEMBLY["failures"]
+    ]
 
     assert subassembly.name == GENERATOR_SUBASSEMBLY["name"]
     assert subassembly.system_value == GENERATOR_SUBASSEMBLY["system_value"]
@@ -426,11 +425,11 @@ def test_SubassemblyData():
 
     # Set the request ID for all failure tasks to avoid an AttributeError
     request = "R000000"
-    for i, level in enumerate(failure_dict):
+    for i, failure in enumerate(failure_list):
         rid = f"{request}{i}"
-        failure_dict[level].assign_id(request_id=rid)
+        failure.assign_id(request_id=rid)
         subassembly.failures[i].assign_id(request_id=rid)
-        assert failure_dict[level] == subassembly.failures[i]
+        assert failure_list[i] == subassembly.failures[i]
 
 
 def test_RepairRequest():

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1,6 +1,10 @@
 """Tests for wombat/core/library.py."""
 
-from wombat.core.library import load_yaml, library_map
+from copy import deepcopy
+
+import pytest
+
+from wombat.core.library import load_yaml, library_map, convert_failure_data
 
 
 def test_load_yaml():
@@ -22,8 +26,8 @@ def test_load_yaml():
                     "frequency": 0,
                 }
             ],
-            "failures": {
-                1: {
+            "failures": [
+                {
                     "scale": 0,
                     "shape": 0,
                     "time": 0,
@@ -33,7 +37,7 @@ def test_load_yaml():
                     "level": 1,
                     "description": "n/a",
                 }
-            },
+            ],
         },
     }
 
@@ -115,3 +119,182 @@ def test_load_yaml():
 
     ctv = load_yaml(library / folder, "ctv1.yaml")
     assert ctv == correct_ctv
+
+
+def test_convert_failure_dict():
+    """Tests dictionary conversion of configs with failure data."""
+    base_config = {
+        "cables": {
+            "base": {
+                "capacity_kw": 0,
+                "capex_kw": 0,
+                "name": "substation",
+                "maintenance": [
+                    {
+                        "description": "n/a",
+                        "time": 0,
+                        "materials": 0,
+                        "service_equipment": "CTV",
+                        "frequency": 0,
+                    }
+                ],
+                "failures": {
+                    1: {
+                        "scale": 0,
+                        "shape": 0,
+                        "time": 0,
+                        "materials": 0,
+                        "service_equipment": ["CTV"],
+                        "operation_reduction": 0,
+                        "level": 1,
+                        "description": "n/a",
+                    }
+                },
+            },
+        },
+        "substations": {
+            "base": {
+                "capacity_kw": 0,
+                "capex_kw": 0,
+                "transformer": {
+                    "name": "substation",
+                    "maintenance": [
+                        {
+                            "description": "n/a",
+                            "time": 0,
+                            "materials": 0,
+                            "service_equipment": "CTV",
+                            "frequency": 0,
+                        }
+                    ],
+                    "failures": {
+                        1: {
+                            "scale": 0,
+                            "shape": 0,
+                            "time": 0,
+                            "materials": 0,
+                            "service_equipment": ["CTV"],
+                            "operation_reduction": 0,
+                            "level": 1,
+                            "description": "n/a",
+                        }
+                    },
+                },
+            },
+        },
+        "turbines": {
+            "sample": {
+                "capacity_kw": 0,
+                "capex_kw": 0,
+                "generator": {
+                    "name": "substation",
+                    "maintenance": [
+                        {
+                            "description": "n/a",
+                            "time": 0,
+                            "materials": 0,
+                            "service_equipment": "CTV",
+                            "frequency": 0,
+                        }
+                    ],
+                    "failures": {
+                        1: {
+                            "scale": 0,
+                            "shape": 0,
+                            "time": 0,
+                            "materials": 0,
+                            "service_equipment": ["CTV"],
+                            "operation_reduction": 0,
+                            "level": 1,
+                            "description": "n/a",
+                        }
+                    },
+                },
+            },
+        },
+    }
+    correct_config = deepcopy(base_config)
+    correct_config["cables"]["base"]["failures"] = list(
+        correct_config["cables"]["base"]["failures"].values()
+    )
+    correct_config["substations"]["base"]["transformer"]["failures"] = list(
+        correct_config["substations"]["base"]["transformer"]["failures"].values()
+    )
+    correct_config["turbines"]["sample"]["generator"]["failures"] = list(
+        correct_config["turbines"]["sample"]["generator"]["failures"].values()
+    )
+    assert correct_config == convert_failure_data(
+        base_config, "configuration", return_dict=True
+    )
+
+    base_system = {
+        "capacity_kw": 0,
+        "capex_kw": 0,
+        "transformer": {
+            "name": "substation",
+            "maintenance": [
+                {
+                    "description": "n/a",
+                    "time": 0,
+                    "materials": 0,
+                    "service_equipment": "CTV",
+                    "frequency": 0,
+                }
+            ],
+            "failures": {
+                1: {
+                    "scale": 0,
+                    "shape": 0,
+                    "time": 0,
+                    "materials": 0,
+                    "service_equipment": ["CTV"],
+                    "operation_reduction": 0,
+                    "level": 1,
+                    "description": "n/a",
+                }
+            },
+        },
+    }
+    correct_system = deepcopy(base_system)
+    correct_system["transformer"]["failures"] = list(
+        correct_system["transformer"]["failures"].values()
+    )
+    assert correct_system == convert_failure_data(
+        base_system, "substation", return_dict=True
+    )
+    assert correct_system == convert_failure_data(
+        base_system, "turbine", return_dict=True
+    )
+
+    base_cable = {
+        "capacity_kw": 0,
+        "capex_kw": 0,
+        "name": "base",
+        "maintenance": [
+            {
+                "description": "n/a",
+                "time": 0,
+                "materials": 0,
+                "service_equipment": "CTV",
+                "frequency": 0,
+            }
+        ],
+        "failures": {
+            1: {
+                "scale": 0,
+                "shape": 0,
+                "time": 0,
+                "materials": 0,
+                "service_equipment": ["CTV"],
+                "operation_reduction": 0,
+                "level": 1,
+                "description": "n/a",
+            }
+        },
+    }
+    correct_cable = deepcopy(base_cable)
+    correct_cable["failures"] = list(correct_cable["failures"].values())
+    assert correct_cable == convert_failure_data(base_cable, "cable", return_dict=True)
+
+    with pytest.raises(ValueError):
+        convert_failure_data(base_cable, "cables", return_dict=True)

--- a/tests/test_subassembly.py
+++ b/tests/test_subassembly.py
@@ -36,8 +36,7 @@ def test_subassembly_initialization(env_setup):
     correct_N_maintenance = len(GENERATOR_SUBASSEMBLY["maintenance"])
     correct_N_failures = len(GENERATOR_SUBASSEMBLY["failures"])
     correct_descriptions = [
-        (el["level"], el["description"])
-        for el in GENERATOR_SUBASSEMBLY["failures"].values()
+        (el["level"], el["description"]) for el in GENERATOR_SUBASSEMBLY["failures"]
     ]
     correct_descriptions.extend(
         [el["description"] for el in GENERATOR_SUBASSEMBLY["maintenance"]]

--- a/wombat/core/library.py
+++ b/wombat/core/library.py
@@ -189,6 +189,7 @@ def convert_failure_data(
         Raised if :py:attr:`which` received an invalid input.
     """
     configuration = deepcopy(configuration)
+    original = deepcopy(configuration)
     if isinstance(configuration, str):
         configuration = Path(configuration)
     if isinstance(configuration, Path):
@@ -199,7 +200,11 @@ def convert_failure_data(
         configuration = load_yaml(configuration.parent, configuration.name)
 
     if not isinstance(configuration, dict):
-        raise ValueError("The `configuration` could not be converted to a dictionary.")
+        if isinstance(original, (str, Path)):
+            msg = f"{original} could not be converted to a dictionary."
+        else:
+            msg = "Input to `configuration` was not a dictionary."
+        raise TypeError(msg)
 
     opts = ("cable", "turbine", "substation", "configuration")
     match which:

--- a/wombat/core/library.py
+++ b/wombat/core/library.py
@@ -21,6 +21,7 @@ signifies the user's input library path:
 from __future__ import annotations
 
 import re
+from copy import deepcopy
 from typing import Any
 from pathlib import Path
 
@@ -147,3 +148,97 @@ def create_library_structure(
         if create_init:
             f = f / "__init__.py"
             f.touch()
+
+
+def convert_failure_data(
+    configuration: str | Path | dict,
+    which: str,
+    save_name: str | Path | None = None,
+    return_dict: bool = False,
+) -> None | dict:
+    """Converts the failure configuration data for cable, turbine, substation data
+    in both individual files or consolidated configurations.
+
+    Parameters
+    ----------
+    configuration : str | Path | dict
+        The configuration file or dictionary containing failure data.
+    which : str
+        The type of configuration. Muat be one of "cable", "substation", "turbine",
+        or "configuration" where "configuration" is a consolidated simulation
+        configuration file containing any or all of the different types.
+    save_name : str | Path | None, optional
+        The file path and name of where to save the converted configuration, by default
+        None.
+    return_dict : bool, optional
+        Use True to return the converted dictionary, by default False.
+
+    Returns
+    -------
+    None | dict
+        If :py:attr:`return_dict` is True, then `dict`, otherwise None.
+
+    Raises
+    ------
+    FileNotFoundError
+        Raised if the :py:attr:`configuration` can't be found.
+    ValueError
+        Raised if :py:attr:`configuration` can't be converted to a dictionary because
+        a dictionary was not passed nor was a valid file path to load.
+    ValueError
+        Raised if :py:attr:`which` received an invalid input.
+    """
+    configuration = deepcopy(configuration)
+    if isinstance(configuration, str):
+        configuration = Path(configuration)
+    if isinstance(configuration, Path):
+        configuration = configuration.resolve()
+        if not configuration.is_file():
+            msg = f"{configuration} cannot be found, please check the path."
+            raise FileNotFoundError(msg)
+        configuration = load_yaml(configuration.parent, configuration.name)
+
+    if not isinstance(configuration, dict):
+        raise ValueError("The `configuration` could not be converted to a dictionary.")
+
+    opts = ("cable", "turbine", "substation", "configuration")
+    match which:
+        case "cable":
+            configuration["failures"] = list(configuration["failures"].values())
+        case "turbine" | "substation":
+            for key, val in configuration.items():
+                if not isinstance(val, dict) or key == "power_curve":
+                    continue
+                configuration[key]["failures"] = list(
+                    configuration[key]["failures"].values()
+                )
+        case "configuration":
+            if "cables" in configuration:
+                for name, config in configuration["cables"].items():
+                    configuration["cables"][name]["failures"] = list(
+                        config["failures"].values()
+                    )
+            if "turbines" in configuration:
+                for name, config in configuration["turbines"].items():
+                    for key, val in config.items():
+                        if isinstance(val, dict) and key != "power_curve":
+                            configuration["turbines"][name][key]["failures"] = list(
+                                val["failures"].values()
+                            )
+            if "substations" in configuration:
+                for name, config in configuration["substations"].items():
+                    for key, val in config.items():
+                        if isinstance(val, dict):
+                            configuration["substations"][name][key]["failures"] = list(
+                                val["failures"].values()
+                            )
+        case _:
+            raise ValueError(f"`which` must be one of: {', '.join(opts)}")
+
+    if save_name is not None:
+        with Path(save_name).open("w") as f:
+            yaml.dump(configuration, f, default_flow_style=False, sort_keys=False)
+
+    if return_dict:
+        return configuration
+    return None

--- a/wombat/core/library.py
+++ b/wombat/core/library.py
@@ -76,7 +76,7 @@ def load_yaml(path: str | Path, fname: str | Path) -> Any:
     path : str | Path
         Path to the file to be loaded.
     fname : str | Path
-        Name of the file (ending in .yaml) to be loaded.
+        Name of the file (ending in .yaml or .yml) to be loaded.
 
     Returns
     -------
@@ -95,19 +95,19 @@ def create_library_structure(
     """Creates the following library structure at ``library_path``. If ``library_path``
     does not exist, then the method will fail.
 
-    ```
-    <library_path>
-    ├── project
-        ├── config     <- Project-level configuration files
-        ├── port       <- Port configuration files
-        ├── plant      <- Wind farm layout files
-    ├── cables       <- Export and Array cable configuration files
-    ├── substations  <- Substation configuration files
-    ├── turbines     <- Turbine configuration and power curve files
-    ├── vessels      <- Land-based and offshore servicing equipment configuration files
-    ├── weather      <- Weather profiles
-    ├── results      <- The analysis log files and any saved output data
-    ```
+    .. code-block:: text
+
+        <library_path>/
+        └── project
+            └── config     <- Project-level configuration files
+            └── port       <- Port configuration files
+            └── plant      <- Wind farm layout files
+        └── cables       <- Export and Array cable configuration files
+        └── substations  <- Substation configuration files
+        └── turbines     <- Turbine configuration and power curve files
+        └── vessels      <- Land-based and offshore servicing equipment configuration files
+        └── weather      <- Weather profiles
+        └── results      <- The analysis log files and any saved output data
 
     Parameters
     ----------
@@ -122,7 +122,7 @@ def create_library_structure(
     ------
     FileNotFoundError
         Raised if ``library_path`` is not a directory
-    """
+    """  # noqa: E501
     if isinstance(library_path, str):
         library_path = Path(library_path)
     library_path = library_path.resolve(strict=True)
@@ -156,8 +156,9 @@ def convert_failure_data(
     save_name: str | Path | None = None,
     return_dict: bool = False,
 ) -> None | dict:
-    """Converts the failure configuration data for cable, turbine, substation data
-    in both individual files or consolidated configurations.
+    """Converts the pre-v0.10 failure configuration data for cable, turbine, substation
+    data in both individual files or consolidated configurations to be in the v0.10+
+    style.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR adopts the use of lists for failure configurations to mirror the simplicity of definition used by the maintenance tasks. To accompany this breaking change, the `wombat.core.library.convert_failure_data()` function can be used to convert cable, substation, turbine, and consolidated configuration files and dictionaries seamlessly.