### PR TITLE
Fix: Bump upload artifact for gh pages

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -28,7 +28,7 @@ jobs:
         jupyter-book build docs
 
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v4
       with:
         path: "docs/_build/html"
 


### PR DESCRIPTION
This PR updates the GH Pages artifact uploading version.