### PR TITLE
Fix: Improper reinitialization of maintenance event timing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,13 +25,13 @@ IMPORTANT NOTES
 <!--The title should clearly define your contribution succinctly.-->
 # Add meaningful title here
 
-<!-- Describe your feature here. Please include any code snippets or examples in this section. -->
+<!-- Describe your contribution here. Please include any code snippets or examples in this section. -->
 
 
 ## PR Checklist
 
 <!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
-- [ ] `RELEASE.md` has been updated to describe the changes made in this PR
+- [ ] `CHANGELOG.md` has been updated to describe the changes made in this PR
 - [ ] Documentation
   - [ ] Docstrings are up-to-date
   - [ ] Related `docs/` files are up-to-date, or added when necessary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v0.10.1 [4 April 2025]
+
+Patch release addressing improper setup logic for the new date-based
+maintenance following subassembly replacements.
+
 ## v0.10 [26 March 2025]
 
 ### Features

--- a/tests/test_cable.py
+++ b/tests/test_cable.py
@@ -1,5 +1,7 @@
 """Test the Cable system and subassembly classes."""
 
+import pytest
+
 from wombat.core import RepairManager
 from wombat.windfarm import Windfarm
 from wombat.windfarm.system import Cable
@@ -82,13 +84,20 @@ def test_cable_failures(env_setup):
     assert cable.broken
     assert cable.operating_level == 0
 
-    # Assert that all items that are timed are non existent or set to the very end
+    # Assert that all items that are timed are non existent or set to the end + buffer
+    # from pprint import pprint
     # for p in cable.processes.values():
     #     pprint(p._target.__dict__)
-    assert getattr(list(cable.processes.values())[0]._target, "_delay", None) is None
-    assert (
-        getattr(list(cable.processes.values())[1]._target, "_delay", None)
-        == env.max_run_time - catastrophic_timeout
+    non_modeled_timeout = getattr(
+        list(cable.processes.values())[0]._target, "_delay", None
+    )
+    assert non_modeled_timeout is None
+
+    post_sim_timeout = getattr(
+        list(cable.processes.values())[1]._target, "_delay", None
+    )
+    assert post_sim_timeout == pytest.approx(
+        env.max_run_time - catastrophic_timeout + 23
     )
 
     # Check the failure was submitted and no other items exist for this cable

--- a/tests/test_data_classes.py
+++ b/tests/test_data_classes.py
@@ -433,8 +433,8 @@ def test_Maintenance_no_events():
     assert cls.frequency == relativedelta(hours=max_run_time)
     assert cls.frequency_basis == "date-hours"
     assert cls.start_date == start
-    assert cls.event_dates == [end + relativedelta(hours=1)]
-    assert cls.hours_to_next_event(start) == (max_run_time + 1, True)
+    assert cls.event_dates == [end + relativedelta(days=1)]
+    assert cls.hours_to_next_event(start) == (max_run_time + 24, True)
     assert cls.service_equipment == ["CTV"]
     assert cls.operation_reduction == class_data["operation_reduction"].default
     assert cls.system_value == 0

--- a/tests/test_subassembly.py
+++ b/tests/test_subassembly.py
@@ -251,7 +251,6 @@ def test_timeouts_for_zeroed_out(env_setup):
         if subassembly.id == "generator":
             continue
         for process in subassembly.processes.values():
-            print(subassembly.id)
             assert process._target._delay in (ENV.max_run_time, ENV.max_run_time + 23)
 
     # Catastrophic failure at 284508.82985483576

--- a/tests/test_subassembly.py
+++ b/tests/test_subassembly.py
@@ -251,7 +251,8 @@ def test_timeouts_for_zeroed_out(env_setup):
         if subassembly.id == "generator":
             continue
         for process in subassembly.processes.values():
-            assert process._target._delay == ENV.max_run_time
+            print(subassembly.id)
+            assert process._target._delay in (ENV.max_run_time, ENV.max_run_time + 23)
 
     # Catastrophic failure at 284508.82985483576
     # TODO: Don't have a way to test that all update to max_run_time - failure time

--- a/wombat/__init__.py
+++ b/wombat/__init__.py
@@ -4,4 +4,4 @@ from wombat.core import Metrics, Simulation
 from wombat.core.library import create_library_structure
 
 
-__version__ = "0.10"
+__version__ = "0.10.1"

--- a/wombat/core/data_classes.py
+++ b/wombat/core/data_classes.py
@@ -565,7 +565,7 @@ class Maintenance(FromDictMixin):
             diff = relativedelta(hours=max_run_time)
             object.__setattr__(self, "frequency", diff)
             object.__setattr__(self, "frequency_basis", "date-hours")
-            object.__setattr__(self, "event_dates", [end + relativedelta(days=2)])
+            object.__setattr__(self, "event_dates", [end + relativedelta(days=1)])
             return
 
         if not date_based:

--- a/wombat/core/data_classes.py
+++ b/wombat/core/data_classes.py
@@ -565,7 +565,7 @@ class Maintenance(FromDictMixin):
             diff = relativedelta(hours=max_run_time)
             object.__setattr__(self, "frequency", diff)
             object.__setattr__(self, "frequency_basis", "date-hours")
-            object.__setattr__(self, "event_dates", [end + relativedelta(hours=1)])
+            object.__setattr__(self, "event_dates", [end + relativedelta(days=2)])
             return
 
         if not date_based:
@@ -622,7 +622,7 @@ class Maintenance(FromDictMixin):
         for date in self.event_dates:
             if date > now_date:
                 return convert_dt_to_hours(date - now_date)
-
+        print(self.description)
         raise RuntimeError("Setup did not produce an extra event for safety.")
 
     def hours_to_next_event(self, now_date: datetime.datetime) -> tuple[float, bool]:

--- a/wombat/core/data_classes.py
+++ b/wombat/core/data_classes.py
@@ -622,7 +622,6 @@ class Maintenance(FromDictMixin):
         for date in self.event_dates:
             if date > now_date:
                 return convert_dt_to_hours(date - now_date)
-        print(self.description)
         raise RuntimeError("Setup did not produce an extra event for safety.")
 
     def hours_to_next_event(self, now_date: datetime.datetime) -> tuple[float, bool]:

--- a/wombat/core/environment.py
+++ b/wombat/core/environment.py
@@ -504,7 +504,7 @@ class WombatEnvironment(simpy.Environment):
                 .fillna(0.0)
                 .set_index("datetime")
                 .sort_index()
-                .resample("H")
+                .resample("h")
                 .interpolate(limit_direction="both")  # , limit=5)
                 .reset_index(drop=False)
             )

--- a/wombat/windfarm/system/cable.py
+++ b/wombat/windfarm/system/cable.py
@@ -105,7 +105,7 @@ class Cable:
         self.broken.succeed()
 
         # TODO: need to get the time scale of a distribution like this
-        self.processes = dict(self._create_processes())
+        self.processes = dict(self._create_processes(first=True))
 
     def set_string_details(self, start_node: str, substation: str):
         """Sets the starting turbine for the string to be used for traversing the

--- a/wombat/windfarm/system/cable.py
+++ b/wombat/windfarm/system/cable.py
@@ -147,8 +147,15 @@ class Cable:
         self.upstream_nodes = turbines
         self.upstream_cables = cables
 
-    def _create_processes(self):
+    def _create_processes(self, *, first: bool = False):
         """Creates the processes for each of the failure and maintenance types.
+
+        Parameters
+        ----------
+        first : bool, optional
+            Indicate if this is the initial creation (True), or a recreation following
+            a replacement event (False). When True, the maintenance data are updated
+            from their original inputs to a simulation-ready format.
 
         Yields
         ------
@@ -156,14 +163,19 @@ class Cable:
             Creates a dictionary to keep track of the running processes within the
             subassembly.
         """
+        if first:
+            for maintenance in self.data.maintenance:
+                maintenance._update_event_timing(
+                    self.env.start_datetime,
+                    self.env.end_datetime,
+                    self.env.max_run_time,
+                )
+
         for failure in self.data.failures:
             desc = failure.description
             yield desc, self.env.process(self.run_single_failure(failure))
 
-        for i, maintenance in enumerate(self.data.maintenance):
-            maintenance._update_event_timing(
-                self.env.start_datetime, self.env.end_datetime, self.env.max_run_time
-            )
+        for maintenance in self.data.maintenance:
             desc = maintenance.description
             yield desc, self.env.process(self.run_single_maintenance(maintenance))
 

--- a/wombat/windfarm/system/subassembly.py
+++ b/wombat/windfarm/system/subassembly.py
@@ -56,10 +56,17 @@ class Subassembly:
         self.broken = self.env.event()
         self.broken.succeed()  # start the event as inactive
 
-        self.processes = dict(self._create_processes())
+        self.processes = dict(self._create_processes(first=True))
 
-    def _create_processes(self):
+    def _create_processes(self, *, first: bool = False):
         """Creates the processes for each of the failure and maintenance types.
+
+        Parameters
+        ----------
+        first : bool, optional
+            Indicate if this is the initial creation (True), or a recreation following
+            a replacement event (False). When True, the maintenance data are updated
+            from their original inputs to a simulation-ready format.
 
         Yields
         ------
@@ -67,10 +74,13 @@ class Subassembly:
             Creates a dictionary to keep track of the running processes within the
             subassembly.
         """
-        for maintenance in self.data.maintenance:
-            maintenance._update_event_timing(
-                self.env.start_datetime, self.env.end_datetime, self.env.max_run_time
-            )
+        if first:
+            for maintenance in self.data.maintenance:
+                maintenance._update_event_timing(
+                    self.env.start_datetime,
+                    self.env.end_datetime,
+                    self.env.max_run_time,
+                )
 
         for failure in self.data.failures:
             level = failure.level


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELTE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code higlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Fix: Improper reinitialization of maintenance event timing

<!-- Describe your feature here. Please include any code snippets or examples in this section. -->
This PR fixes an uncaught bug in the development of the date-based maintenance feature released in 0.10. When a subassembly is replaced, the conversion of the user input to a timeout schedule was triggered again. This reinitialization caused runs to fail because of improper type interactions. This update ensures the setup logic is only run at subassembly initialization.

## PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [x] `RELEASE.md` has been updated to describe the changes made in this PR
- [ ] Documentation - N/A
  - [x] Docstrings are up-to-date
  - [ ] Related `docs/` files are up-to-date, or added when necessary - N/A
  - [ ] Documentation has been rebuilt successfully - N/A
  - [ ] Examples have been updated - N/A
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [x] PR description thoroughly describes the new feature, bug fix, etc.

## Related issues

<!--If one exists, link to a related GitHub Issue.-->
N/A

## Impacted areas of the software

<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why.
-->
- Updates buffer for maintenance events
  - `test/test_subassembly.py`
  - `test/test_data_classes.py`
  - test/test_cable.py`
- Ensures maintenance is initialized once
  - `wombat/windfarm/system/cable.py`
  - `wombat/windfarm/system/subassembly.py`
- `wombat/core/environment.py`: fixes a future warning for pandas offsets
- `wombat/core/data_classes.py`: change buffer from 1 hour to 1 day

## Additional supporting information

<!--Fil out at least the versions listed below and those of any packages that may be related.-->
Python version: 3.x
WOMBAT version (`wombat.__version__`): 0.x

<!--Add any other context about the problem here.-->


## Test results, if applicable

<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->
