### PR TITLE
Patch: Dispatch timing conflict & end of simulation check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v0.10.4 (12 May 2025)
+
+- Fix a bug where tow-to-port strategies can result in vessels being dispatched and
+  accruing wasted costs when a repair is handed off to a report. An additional check
+  is added where if there are no requests, but the servicing equipment has not yet been
+  mobilized, the servicing equipment dispatch is canceled.
+- Update an end of simulation timing check to ensure compatibility with PolaRS and
+  Python datetime stamps that causes the simulation to fail when an action cannot
+  be completed before the end of the simulation.
+
 ## v0.10.3 (24 April 2025)
 
 - Fix a bug in `Metrics.component_costs` where the materials costs are excluded when results are

--- a/wombat/__init__.py
+++ b/wombat/__init__.py
@@ -4,4 +4,4 @@ from wombat.core import Metrics, Simulation
 from wombat.core.library import create_library_structure
 
 
-__version__ = "0.10.3"
+__version__ = "0.10.4"

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -908,7 +908,7 @@ class ServiceEquipment(RepairsMixin):
             # that it's not due to having reached the end of the simulation. If so,
             # return the max amount of time, but if that's not the case re-raise the
             # error.
-            if self.env.end_datetime in dt:
+            if (self.env.end_datetime == dt).any():
                 ix_hours = distance_traveled.shape[0] - 1
             else:
                 raise e
@@ -1756,6 +1756,10 @@ class ServiceEquipment(RepairsMixin):
         while True and self.env.now < charter_end_env_time:
             _, request = self.get_next_request()
             if request is None:
+                if not self.onsite:
+                    self.dispatched = False
+                    return
+
                 yield self.env.process(
                     self.wait_until_next_shift(
                         **{


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELTE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code higlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Patch: Dispatch timing conflict & end of simulation check 

<!-- Describe your contribution here. Please include any code snippets or examples in this section. -->
This PR fixes two small issues in the servicing equipment logic.
1. Unscheduled servicing equipment now check if they have not been mobilized and there are no requests they can address. When this is the case, they now cancel their dispatching without accruing any costs.
2. The end of simulation check in travel time is updated for compatibility with Python's datetime (microsecond resolution) and PolaRS' datetime (nanosecond resolution).

## PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [x] `CHANGELOG.md` has been updated to describe the changes made in this PR
- [ ] Documentation
  - [x] Docstrings are up-to-date
  - [ ] Related `docs/` files are up-to-date, or added when necessary
  - [ ] Documentation has been rebuilt successfully
  - [ ] Examples have been updated
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [x] PR description thoroughly describes the new feature, bug fix, etc.

## Related issues

<!--If one exists, link to a related GitHub Issue.-->
N/A

## Impacted areas of the software

<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why.
-->
- `wombat/core/service_equipment.py`
  - `ServiceEquipment.run_unscheduled_in_situ()`: A bug where excess unproductive accumulates for tow-to-port scenarios was caused by the port taking over repair requests from a vessel between its initial dispatching and its mobilization. When this occurred, the vessel would operate for the charter and mobilization period, and accrue costs. A new check has been added to cancel the dispatching without accruing any cost.
  - `ServiceEquipment._calculate_interrupted_travel_time()`: The check for the end of the simulation relied on deprecated logic to compare Python datetimes and PolaRS datetimes, which now have different resolutions, so a new check for the end of the simulation being present in the weather window has been implemented.

## Additional supporting information

<!--Fil out at least the versions listed below and those of any packages that may be related.-->
Python version: 3.x
WOMBAT version (`wombat.__version__`): 0.x

<!--Add any other context about the problem here.-->


## Test results, if applicable

<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->
