### PR TITLE
Enhancement: Initialization error message improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@
 - Drops support for Python 3.10.
 - `Metrics.component_costs` has been refactored, and now includes two additional breakdowns:
   - `by_task`: toggles the inclusion of the individual repair and maintenance tasks.
-  - `include_travel`: tooggles the inclusion of intrasite and port-to-site travel.
+  - `include_travel`: toggles the inclusion of intrasite and port-to-site travel.
+- Improved cable, subassembly, and servicing equipment error handling to show which of
+  the cables, substations, turbines, or vessels produced the intialization error for
+  easier input debugging.
 
 ## v0.10.4 (12 May 2025)
 

--- a/wombat/core/service_equipment.py
+++ b/wombat/core/service_equipment.py
@@ -243,8 +243,11 @@ class ServiceEquipment(RepairsMixin):
             # Ignores for unscheduled maintenace equipment that won't have this input
             pass
 
-        # NOTE: mypy is not caught up with attrs yet :(
-        self.settings = ServiceEquipmentData(data).determine_type()  # type: ignore
+        try:
+            self.settings = ServiceEquipmentData(data).determine_type()  # type: ignore
+        except Exception as e:
+            msg = f"Could not create {data['name']}"
+            raise ValueError(msg) from e
 
         # Register servicing equipment with the repair manager if it is using an
         # unscheduled maintenance scenario, so it can be dispatched as needed

--- a/wombat/windfarm/system/cable.py
+++ b/wombat/windfarm/system/cable.py
@@ -93,7 +93,7 @@ class Cable:
             self.data = SubassemblyData.from_dict(cable_data)
         except Exception as e:
             msg = f"Could not create {self.id}"
-            raise RuntimeError(msg) from e
+            raise ValueError(msg) from e
 
         self.system_name = self.data.name
         self.name = self.data.name if name is None else name

--- a/wombat/windfarm/system/cable.py
+++ b/wombat/windfarm/system/cable.py
@@ -92,7 +92,7 @@ class Cable:
         try:
             self.data = SubassemblyData.from_dict(cable_data)
         except Exception as e:
-            msg = f"Could not create {self.id}"
+            msg = f"Could not create {self.connection_type} cable: {self.id}"
             raise ValueError(msg) from e
 
         self.system_name = self.data.name

--- a/wombat/windfarm/system/cable.py
+++ b/wombat/windfarm/system/cable.py
@@ -89,7 +89,12 @@ class Cable:
             "system_value": self.system.value,
             "rng": self.env.random_generator,
         }
-        self.data = SubassemblyData.from_dict(cable_data)
+        try:
+            self.data = SubassemblyData.from_dict(cable_data)
+        except Exception as e:
+            msg = f"Could not create {self.id}"
+            raise RuntimeError(msg) from e
+
         self.system_name = self.data.name
         self.name = self.data.name if name is None else name
 

--- a/wombat/windfarm/system/subassembly.py
+++ b/wombat/windfarm/system/subassembly.py
@@ -53,7 +53,7 @@ class Subassembly:
             self.data = SubassemblyData.from_dict(subassembly_data)
         except Exception as e:
             msg = f"Could not create {s_id} for {self.system.id}"
-            raise RuntimeError(msg) from e
+            raise ValueError(msg) from e
         self.name = self.data.name
 
         self.operating_level = 1.0

--- a/wombat/windfarm/system/subassembly.py
+++ b/wombat/windfarm/system/subassembly.py
@@ -52,7 +52,7 @@ class Subassembly:
         try:
             self.data = SubassemblyData.from_dict(subassembly_data)
         except Exception as e:
-            msg = f"Could not create {s_id} for {self.system.id}"
+            msg = f"Could not create {s_id} for {system.system_type}: {system.id}"
             raise ValueError(msg) from e
         self.name = self.data.name
 

--- a/wombat/windfarm/system/subassembly.py
+++ b/wombat/windfarm/system/subassembly.py
@@ -49,7 +49,11 @@ class Subassembly:
             "system_value": self.system.value,
             "rng": self.env.random_generator,
         }
-        self.data = SubassemblyData.from_dict(subassembly_data)
+        try:
+            self.data = SubassemblyData.from_dict(subassembly_data)
+        except Exception as e:
+            msg = f"Could not create {s_id} for {self.system.id}"
+            raise RuntimeError(msg) from e
         self.name = self.data.name
 
         self.operating_level = 1.0


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELTE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code higlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Improve initialization error messages for `Cable`, `System`, and `ServcieEquipment`

<!-- Describe your contribution here. Please include any code snippets or examples in this section. -->
This PR adds additional diagnostic information to any error messages that occur during the data validation step of the cable, system, and service equipment initialization.

## PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [x] `CHANGELOG.md` has been updated to describe the changes made in this PR
- [ ] Documentation
  - [ ] Docstrings are up-to-date
  - [ ] Related `docs/` files are up-to-date, or added when necessary
  - [ ] Documentation has been rebuilt successfully
  - [ ] Examples have been updated
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [x] PR description thoroughly describes the new feature, bug fix, etc.

## Related issues

<!--If one exists, link to a related GitHub Issue.-->
N/A

## Impacted areas of the software

<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why.
-->
- `try`/`except`/`raise from` clause wrapped around the data class validation
  - `wombat/windfarm/system/subassembly.py::Subassembly.__init__()`
  - `wombat/windfarm/system/cable.py::Cable.__init__()`
  - `wombat/core/service_equipment.py::ServiceEquipment.__init__()`

## Additional supporting information

<!--Fil out at least the versions listed below and those of any packages that may be related.-->
Python version: 3.x
WOMBAT version (`wombat.__version__`): 0.x

<!--Add any other context about the problem here.-->
N/A

## Test results, if applicable

<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->
