### PR TITLE
Enhancement: Universal maintenance starting date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - `Metrics.dispatch_summary` is now available to provide the number of mobilizations and average
   charter period across the whole project, or broken down by year and month, as requested.
+- Universalized maintenance starting dates are now able to be set through the primary
+  configuration file as `maintenance_start`. This will enable the universalized
+  staggering of the first instance of a maintenance task to align with a different
+  season than that of the start of the weather profile. This is particularly helpful
+  for Northern Hemisphere projects where winter months can cause significant weather
+  delays.
 
 ### Updates
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Unit tests configuration file."""
 
+import datetime
 from pathlib import Path
 
 import numpy as np
@@ -86,6 +87,7 @@ RNG = np.random.default_rng(seed=34)
 GENERATOR_SUBASSEMBLY = {
     "name": "generator",
     "system_value": 39000000,
+    "maintenance_start": datetime.datetime(2000, 6, 1),
     "maintenance": [
         {
             "description": "annual service",

--- a/tests/library/project/config/base.yml
+++ b/tests/library/project/config/base.yml
@@ -12,4 +12,5 @@ workday_start: 6
 workday_end: 22
 start_year: 2002
 end_year: 2003
+maintenance_start: "6/1/2002"
 project_capacity: 18

--- a/tests/test_simulation_api.py
+++ b/tests/test_simulation_api.py
@@ -1,6 +1,7 @@
 """Test the API functionality."""
 
 import sys
+import datetime
 
 import pytest
 
@@ -14,6 +15,7 @@ def test_simulation_file_setup():
     """Test that a primarily file-defined simulation initializes correctly."""
     sim = Simulation.from_config(TEST_DATA, "base.yml")
 
+    assert sim.env.maintenance_start == datetime.datetime(2002, 6, 1)
     assert len(sim.service_equipment) == 5
     assert len(sim.windfarm.turbine_id) == 6
     assert len(sim.windfarm.substation_id) == 1

--- a/wombat/core/data_classes.py
+++ b/wombat/core/data_classes.py
@@ -356,7 +356,7 @@ def convert_maintenance_list(value: list[dict], self_) -> list[Maintenance]:
     """Converts a list of ``Maintenance`` configuration dictionaries to a list of
     ``Maintenance`` objects.
     """
-    kw = {"system_value": self_.system_value}
+    kw = {"system_value": self_.system_value, "start_date": self_.maintenance_start}
     [el.update(kw) for el in value]
     return [Maintenance.from_dict(el) for el in value]
 
@@ -881,10 +881,14 @@ class SubassemblyData(FromDictMixin):
     system_value : int | float
         Turbine's cost of replacement. Used in case percentages of turbine cost are used
         in place of an absolute cost.
+    maintenance_start : datetime.datetime | None
+        The WombatEnvironment maintenance starting date, which will set the cadence for
+        all maintenance activity this is not otherwise specified.
     """
 
     name: str = field(converter=str)
     system_value: int | float = field(converter=float)
+    maintenance_start: datetime.datetime | None = field()
     rng: np.random._generator.Generator = field(
         validator=attrs.validators.instance_of(np.random._generator.Generator)
     )

--- a/wombat/core/environment.py
+++ b/wombat/core/environment.py
@@ -98,6 +98,11 @@ class WombatEnvironment(simpy.Environment):
         should be used as a base setting when multiple or all servicing equipment
         will be operating out of the same base location, but can be individually
         modified.
+    maintenance_start : str | datetime.datetime | None
+        Universalized starting date to set the cadence of all maintenance activity that
+        has not been individually set. For instance, this enables maintenance activity
+        to be automatically set to start in clear weather months, rather than timed
+        with the start of a simulation.
     non_operational_start : str | datetime.datetime | None
         The starting month and day, e.g., MM/DD, M/D, MM-DD, etc. for an annualized
         period of prohibited operations. When defined at the environment level,
@@ -147,6 +152,7 @@ class WombatEnvironment(simpy.Environment):
         start_year: int | None = None,
         end_year: int | None = None,
         port_distance: int | float | None = None,
+        maintenance_start: str | dt.datetime | None = None,
         non_operational_start: str | dt.datetime | None = None,
         non_operational_end: str | dt.datetime | None = None,
         reduced_speed_start: str | dt.datetime | None = None,
@@ -181,6 +187,7 @@ class WombatEnvironment(simpy.Environment):
         self.shift_length = self.workday_end - self.workday_start
 
         # Set the environmental consideration parameters
+        self.maintenance_start = parse_date(maintenance_start)
         self.non_operational_start = parse_date(non_operational_start)
         self.non_operational_end = parse_date(non_operational_end)
         self.reduced_speed_start = parse_date(reduced_speed_start)

--- a/wombat/core/simulation_api.py
+++ b/wombat/core/simulation_api.py
@@ -87,6 +87,11 @@ class Configuration(FromDictMixin):
     end_year : int
         Final year of the simulation. The exact date will be determined by
         the last valid date of this year in ``weather``.
+    maintenance_start : str | datetime.datetime | None
+        Universalized starting date to set the cadence of all maintenance activity that
+        has not been individually set. For instance, this enables maintenance activity
+        to be automatically set to start in clear weather months, rather than timed
+        with the start of a simulation.
     non_operational_start : str | datetime.datetime | None
         The starting month and day, e.g., MM/DD, M/D, MM-DD, etc. for an annualized
         period of prohibited operations. When defined at the environment level, an
@@ -150,6 +155,7 @@ class Configuration(FromDictMixin):
     start_year: int = field(default=None)
     end_year: int = field(default=None)
     port_distance: int | float = field(default=None)
+    maintenance_start: str | datetime.datetime | None = field(default=None)
     non_operational_start: str | datetime.datetime | None = field(default=None)
     non_operational_end: str | datetime.datetime | None = field(default=None)
     reduced_speed_start: str | datetime.datetime | None = field(default=None)
@@ -372,6 +378,7 @@ class Simulation(FromDictMixin):
             start_year=self.config.start_year,
             end_year=self.config.end_year,
             port_distance=self.config.port_distance,
+            maintenance_start=self.config.maintenance_start,
             non_operational_start=self.config.non_operational_start,
             non_operational_end=self.config.non_operational_end,
             reduced_speed_start=self.config.reduced_speed_start,

--- a/wombat/utilities/time.py
+++ b/wombat/utilities/time.py
@@ -32,8 +32,7 @@ def parse_date(value: str | None | datetime.datetime) -> datetime.datetime | Non
     if isinstance(value, datetime.datetime):
         return value
 
-    # Ensure there is a common comparison year for all datetime values
-    return parse(value).replace(year=2022)
+    return parse(value)
 
 
 def convert_dt_to_hours(diff: datetime.timedelta) -> float:

--- a/wombat/windfarm/system/cable.py
+++ b/wombat/windfarm/system/cable.py
@@ -88,6 +88,7 @@ class Cable:
             **cable_data,
             "system_value": self.system.value,
             "rng": self.env.random_generator,
+            "maintenance_start": self.env.maintenance_start,
         }
         try:
             self.data = SubassemblyData.from_dict(cable_data)

--- a/wombat/windfarm/system/subassembly.py
+++ b/wombat/windfarm/system/subassembly.py
@@ -48,6 +48,7 @@ class Subassembly:
             **subassembly_data,
             "system_value": self.system.value,
             "rng": self.env.random_generator,
+            "maintenance_start": self.env.maintenance_start,
         }
         try:
             self.data = SubassemblyData.from_dict(subassembly_data)


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELTE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code higlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Enable universalized maintenance start timing

<!-- Describe your contribution here. Please include any code snippets or examples in this section. -->
This PR expands the new maintenance starting date feature to include a universalized starting date that can be set through the main configuration file. This primary functionality of this feature is to enable scenarios where a weather profiles starts with a new year, but maintenance timing would start in the summer for the Northern Hemisphere. By staggering the starting time universally, this significantly reduces the cost of maintenance activity that may suffer from extensive delays due to harsh weather conditions.

## PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [x] `CHANGELOG.md` has been updated to describe the changes made in this PR
- [x] Documentation
  - [x] Docstrings are up-to-date
  - [x] Related `docs/` files are up-to-date, or added when necessary
  - [x] Documentation has been rebuilt successfully
  - [x] Examples have been updated
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [x] PR description thoroughly describes the new feature, bug fix, etc.

## Related issues

<!--If one exists, link to a related GitHub Issue.-->
N/A

## Impacted areas of the software

<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why.
-->
- Primary configurations have been updated to include the new input and handle, string, datetime, and None inputs.
  - `wombat/core/environment.py::WombatEnvironment`
  - `wombat/core/simulation_api.py::Configuration`
  - `wombat/core/simulation_api.py::Simulation`
- Anywhere that creates a `SubassemblyData` object, now extracts the environments `maintenance_start` and applies it to the maintenance creation routines.
  - `wombat/windfarm/system/subassembly.py`
  - `wombat/windfarm/system/cable.py`
- `wombat/utilities/time.py::parse_date()`: no longer sets 2022 as the base year for all date parsing. It's unclear where this came from and why it is used.
- `tests/`
  - Tests have been updated to ensure the new `maintenance_start` variable is passed through correctly.

## Additional supporting information

<!--Fil out at least the versions listed below and those of any packages that may be related.-->
Python version: 3.x
WOMBAT version (`wombat.__version__`): 0.x

<!--Add any other context about the problem here.-->
N/A

## Test results, if applicable

<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->
Tests pass and have been updated.