### PR TITLE
Patch: Minor metrics and simulation timing updates

### DIFF
--- a/tests/test_data_classes.py
+++ b/tests/test_data_classes.py
@@ -333,6 +333,8 @@ def test_Maintenance_frequency():
         datetime.datetime(2000, 7, 1),
         datetime.datetime(2000, 10, 1),
         datetime.datetime(2001, 1, 1),
+        datetime.datetime(2001, 4, 1),
+        datetime.datetime(2001, 7, 1),
     ]
     current_dt = datetime.datetime(2000, 12, 1)
     expected_dt = datetime.datetime(2001, 1, 1)
@@ -366,6 +368,7 @@ def test_Maintenance_frequency():
     assert cls.event_dates == [
         datetime.datetime(2002, 6, 30),
         datetime.datetime(2006, 6, 30),
+        datetime.datetime(2010, 6, 30),
     ]
 
     # Days and prior start date
@@ -381,6 +384,7 @@ def test_Maintenance_frequency():
         datetime.datetime(2000, 6, 28),
         datetime.datetime(2000, 12, 25),
         datetime.datetime(2001, 6, 23),
+        datetime.datetime(2001, 12, 20),
     ]
 
 

--- a/wombat/core/data_classes.py
+++ b/wombat/core/data_classes.py
@@ -692,11 +692,14 @@ class Maintenance(FromDictMixin):
 
         _event_dates = [self.start_date + diff * i for i in range(periods + 2)]
         event_dates = []
+        buffer = False
         for date in _event_dates:
             if date > start:
                 event_dates.append(date)
-                if date >= end:
-                    break
+                if date > end:
+                    if buffer:
+                        break
+                    buffer = True
 
         object.__setattr__(self, "frequency", diff)
         object.__setattr__(self, "event_dates", event_dates)

--- a/wombat/core/post_processor.py
+++ b/wombat/core/post_processor.py
@@ -564,8 +564,6 @@ class Metrics:
         time_cols = frequency.group_cols
         group_cols = deepcopy(time_cols)
         group_cols += deepcopy(self.turbine_id) if by_turbine else ["windfarm"]
-        print(time_cols)
-        print(group_cols)
         if frequency is not Frequency.PROJECT:
             production = production[group_cols].groupby(time_cols).sum()
             potential = potential[group_cols].groupby(time_cols).sum()

--- a/wombat/core/post_processor.py
+++ b/wombat/core/post_processor.py
@@ -815,13 +815,13 @@ class Metrics:
                 ],
                 axis=1,
             )
-            return costs.fillna(value=0)
+            return costs.fillna(value=0).sort_index()
 
         if frequency is Frequency.PROJECT:
             return pd.DataFrame([events[cost_col].sum()], columns=cost_col)
 
         costs = events[cost_col + col_filter].groupby(col_filter).sum()
-        return costs.fillna(0)
+        return costs.fillna(0).sort_index()
 
     def service_equipment_utilization(self, frequency: str) -> pd.DataFrame:
         """Calculates the utilization rate for each of the service equipment in the

--- a/wombat/core/post_processor.py
+++ b/wombat/core/post_processor.py
@@ -1764,7 +1764,10 @@ class Metrics:
 
         part_group = (
             self.events.loc[
-                self.events.action.str.contains("request")
+                (
+                    self.events.action.eq("repair request")
+                    | self.events.action.eq("maintenance request")
+                )
                 & self.events.request_id.str.startswith(("RPR", "MNT")),
                 ["agent", "reason", "request_id", "system_name"],
             ]


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELTE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code higlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Fix minor metrics and simulation timing bugs

<!-- Describe your contribution here. Please include any code snippets or examples in this section. -->
This PR contributes the following fixes for the develop branch:
- Removes extra print statements introduced in the updated `component_costs`.
- Fixes the double counting of materials costs that are introduced when port-based logging is captured in `component_costs`
- Fixes an edge case where maintenance events occurring on the last day of the simulation hit the end of their pre-produced limits, so a second buffer date is included.

## PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [ ] `CHANGELOG.md` has been updated to describe the changes made in this PR
- [ ] Documentation
  - [ ] Docstrings are up-to-date
  - [ ] Related `docs/` files are up-to-date, or added when necessary
  - [ ] Documentation has been rebuilt successfully
  - [ ] Examples have been updated
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [x] PR description thoroughly describes the new feature, bug fix, etc.

## Related issues

<!--If one exists, link to a related GitHub Issue.-->
N/A

## Impacted areas of the software

<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why.
-->
- `wombat/core/post_processor.py`
  - `Metrics.component_costs()`: Removed two print statements, and the extraneous port data capture that double-counts costs
- `wombat/core/data_classes.py`
  - `Maintenance._update_event_timing()`: Produces a second buffer date after the end of the simulation.
- `tests/test_data_classes.py`
  - `test_Maintenance_frequency(): Adds extra events where required for checks.

## Additional supporting information

<!--Fil out at least the versions listed below and those of any packages that may be related.-->
Python version: 3.x
WOMBAT version (`wombat.__version__`): 0.10.4 (on develop branch)

<!--Add any other context about the problem here.-->
N/A

## Test results, if applicable

<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->
