### PR TITLE
Feature: Simulation auto cleanup and CSV -> Parquet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   season than that of the start of the weather profile. This is particularly helpful
   for Northern Hemisphere projects where winter months can cause significant weather
   delays.
+- `Simulation.run()` has a new parameter called `delete_logs` (defaults to False) that
+  allows the user to automatically delete the logging files that are created after the
+  `Metrics` object is initialized.
 
 ### Updates
 
@@ -28,6 +31,8 @@
   tests focus on event timing checks and results checking. Users can now run
   `pytest --unit` or `pytest --regression` if a subset of the tests are needing to be
   run with `pytest` still running the entire test suite.
+- Post-results log files have been converted from a CSV to Parquet file format for
+  faster I/O and a smaller memory footprint.
 
 ## v0.10.4 (12 May 2025)
 

--- a/tests/unit/test_simulation_api.py
+++ b/tests/unit/test_simulation_api.py
@@ -50,10 +50,9 @@ def test_simulation_consolidated_setup():
 def test_metrics_save_load():
     """Tests that the saved metrics data can be reused."""
     sim = Simulation.from_config(TEST_DATA, "base_consolidated.yml")
-    sim.run()
+    sim.run(save_metrics_inputs=True)
 
     metrics = sim.metrics
-    sim.save_metrics_inputs()
 
     metrics_reloaded = Metrics.from_simulation_outputs(
         fpath=TEST_DATA / "results", fname=sim.env.metrics_input_fname

--- a/wombat/core/environment.py
+++ b/wombat/core/environment.py
@@ -275,8 +275,8 @@ class WombatEnvironment(simpy.Environment):
 
         events_log_fname = f"{dt_stamp}_{simulation}_events.csv"
         operations_log_fname = f"{dt_stamp}_{simulation}_operations.csv"
-        power_potential_fname = f"{dt_stamp}_{simulation}_power_potential.csv"
-        power_production_fname = f"{dt_stamp}_{simulation}_power_production.csv"
+        power_potential_fname = f"{dt_stamp}_{simulation}_power_potential.pqt"
+        power_production_fname = f"{dt_stamp}_{simulation}_power_production.pqt"
         metrics_input_fname = f"{dt_stamp}_{simulation}_metrics_inputs.yaml"
 
         log_path = self.data_dir / "results"
@@ -760,6 +760,9 @@ class WombatEnvironment(simpy.Environment):
         pd.DataFrame
             The formatted logging data from a simulation.
         """
+        if self.events_log_fname.suffix == ".pqt":
+            return pd.read_parquet(self.events_log_fname)
+
         log_df = (
             pd.read_csv(
                 self.events_log_fname,
@@ -826,6 +829,9 @@ class WombatEnvironment(simpy.Environment):
         pd.DataFrame
             The formatted logging data from a simulation.
         """
+        if self.operations_log_fname.suffix == ".pqt":
+            return pd.read_parquet(self.operations_log_fname)
+
         log_df = (
             pd.read_csv(
                 self.operations_log_fname,
@@ -849,7 +855,37 @@ class WombatEnvironment(simpy.Environment):
         )
         return log_df
 
-    def power_production_potential_to_csv(  # type: ignore
+    def convert_logs_to_pqt(
+        self, events: pd.DataFrame | None = None, operations: pd.DataFrame | None = None
+    ) -> None:
+        """Convert the CSV logging files to parquet for more efficient data storage.
+        This method is intended to be used after the simulation has completed as it will
+        also convert the filname references to use ".pqt" in place of ".csv".
+
+        Parameters
+        ----------
+        events : pd.DataFrame | None, optional
+            The events dataframe to be used, if it is already loaded. If None, then the
+            data will be loaded and converted here, by default None.
+        operations : pd.DataFrame | None, optional
+            The operations dataframe to be used, if it is already loaded. If None, then
+            the data will be loaded and converted here, by default None
+        """
+        if events is None:
+            events = self.load_events_log_dataframe()
+        if operations is None:
+            operations = self.load_operations_log_dataframe()
+
+        self.events_log_fname = self.events_log_fname.with_suffix(".pqt")
+        self.operations_log_fname = self.operations_log_fname.with_suffix(".pqt")
+
+        events.to_parquet(self.events_log_fname)
+        operations.to_parquet(self.operations_log_fname)
+
+        self.events_log_fname.with_suffix(".csv").unlink()
+        self.operations_log_fname.with_suffix(".csv").unlink()
+
+    def power_production_potential_to_pqt(  # type: ignore
         self,
         windfarm: wombat.windfarm.Windfarm,
         operations: pd.DataFrame | None = None,
@@ -873,8 +909,6 @@ class WombatEnvironment(simpy.Environment):
         Tuple[pd.DataFrame, pd.DataFrame]
             The power potential and production timeseries data.
         """
-        write_options = pa.csv.WriteOptions(delimiter="|")
-
         if operations is None:
             operations = self.load_operations_log_dataframe().sort_values("env_time")
 
@@ -896,11 +930,7 @@ class WombatEnvironment(simpy.Environment):
             env_time=operations.env_time.values,
             env_datetime=operations.env_datetime.values,
         )
-        pa.csv.write_csv(
-            pa.Table.from_pandas(potential_df, preserve_index=False),
-            self.power_potential_fname,
-            write_options=write_options,
-        )
+        potential_df.to_parquet(self.power_potential_fname)
 
         # TODO: The actual windfarm production needs to be clipped at each subgraph to
         # the max of the substation's operating capacity and then summed.
@@ -909,11 +939,7 @@ class WombatEnvironment(simpy.Environment):
         production_df.windfarm = self._calculate_adjusted_production(
             operations, production_df
         )
-        pa.csv.write_csv(
-            pa.Table.from_pandas(production_df, preserve_index=False),
-            self.power_production_fname,
-            write_options=write_options,
-        )
+        production_df.to_parquet(self.power_production_fname)
         if return_df:
             return potential_df, production_df
 

--- a/wombat/core/post_processor.py
+++ b/wombat/core/post_processor.py
@@ -113,17 +113,17 @@ class Metrics:
         data_dir : str | Path
             This should be the same as was used for running the analysis.
         events : str | pd.DataFrame
-            Either a pandas ``DataFrame`` or filename to be used to read the csv log
+            Either a pandas ``DataFrame`` or filename to be used to read the .pqt log
             data.
         operations : str | pd.DataFrame
-            Either a pandas ``DataFrame`` or filename to be used to read the csv log
+            Either a pandas ``DataFrame`` or filename to be used to read the .pqt log
             data.
         potential : str | pd.DataFrame
-            Either a pandas ``DataFrame`` or a filename to be used to read the csv
+            Either a pandas ``DataFrame`` or a filename to be used to read the .pqt
             potential power production data.
         production : str | pd.DataFrame
-            Either a pandas ``DataFrame`` or a filename to be used to read the csv power
-            production data.
+            Either a pandas ``DataFrame`` or a filename to be used to read the .pqt
+            power production data.
         inflation_rate : float
             The inflation rate to be applied to all dollar amounts from the analysis
             starting year to ending year.
@@ -320,13 +320,13 @@ class Metrics:
         return metrics
 
     def _tidy_data(self, data: pd.DataFrame) -> pd.DataFrame:
-        """Tidies the "raw" csv-converted data to be able to be used among the
+        """Tidies the "raw" parquet-converted data to be able to be used among the
         ``Metrics`` class.
 
         Parameters
         ----------
         data : pd.DataFrame
-            The csv log data.
+            The tabular log data.
 
         Returns
         -------
@@ -354,51 +354,19 @@ class Metrics:
         return data
 
     def _read_data(self, fname: str) -> pd.DataFrame:
-        """Reads the csv log data from library. This is intended to be used for the
-        events or operations data.
+        """Reads the Parquet log data from library's results folder.
 
         Parameters
         ----------
-        path : str
-            Path to the simulation library.
         fname : str
-            Filename of the csv data.
+            Filename of the parquet data.
 
         Returns
         -------
         pd.DataFrame
             Dataframe of either the events or operations data.
         """
-        if "events" in fname:
-            data = (
-                pd.read_csv(
-                    self.data_dir / "outputs" / "logs" / fname,
-                    delimiter="|",
-                    engine="pyarrow",
-                    dtype={
-                        "agent": "string",
-                        "action": "string",
-                        "reason": "string",
-                        "additional": "string",
-                        "system_id": "string",
-                        "system_name": "string",
-                        "part_id": "string",
-                        "part_name": "string",
-                        "request_id": "string",
-                        "location": "string",
-                    },
-                )
-                .set_index("datetime")
-                .sort_index()
-            )
-            return data
-
-        data = pd.read_csv(
-            self.data_dir / "outputs" / "logs" / fname,
-            delimiter="|",
-            engine="pyarrow",
-        )
-        return data
+        return pd.read_parquet(self.data_dir / "results" / fname)
 
     def _apply_inflation_rate(self, events: pd.DataFrame) -> pd.DataFrame:
         """Adjusts the cost data for compounding inflation.

--- a/wombat/core/simulation_api.py
+++ b/wombat/core/simulation_api.py
@@ -457,6 +457,8 @@ class Simulation(FromDictMixin):
             both set to ``True``.
         """
         self.env.run(until=until)
+        self.env.convert_logs_to_pqt()
+
         if create_metrics:
             self.initialize_metrics()
         if delete_logs:
@@ -474,7 +476,6 @@ class Simulation(FromDictMixin):
         """Instantiates the ``metrics`` attribute after the simulation is run."""
         events = self.env.load_events_log_dataframe()
         operations = self.env.load_operations_log_dataframe()
-        self.env.convert_logs_to_pqt()
         power_potential, power_production = self.env.power_production_potential_to_pqt(
             windfarm=self.windfarm, operations=operations, return_df=True
         )

--- a/wombat/core/simulation_api.py
+++ b/wombat/core/simulation_api.py
@@ -425,6 +425,7 @@ class Simulation(FromDictMixin):
         until: int | float | Event | None = None,
         create_metrics: bool = True,
         save_metrics_inputs: bool = True,
+        delete_logs: bool = False,
     ):
         """Calls ``WombatEnvironment.run()`` and gathers the results for
         post-processing. See ``wombat.simulation.WombatEnvironment.run`` or
@@ -442,18 +443,39 @@ class Simulation(FromDictMixin):
             If True, the metrics inputs data will be saved to a yaml file, with file
             references to any larger data structures that can be reloaded later. If
             False, the data will not be saved, by default True.
+        delete_logs : bool, optional
+            If True, automatically run ``Simulation.env.cleanup_log_files()`` after
+            creating and saving any necessary files. If False, the log files will not
+            be deleted. This method should not be used when
+            :py:attr:`save_metrics_inputs` is ``True`` because the files referenced
+            will be deleted.
+
+        Raises
+        ------
+        ValueError
+            Raised when :py:attr:`delete_log_files` :py:attr:`save_metrics_inputs` are
+            both set to ``True``.
         """
         self.env.run(until=until)
-        if save_metrics_inputs:
-            self.save_metrics_inputs()
         if create_metrics:
             self.initialize_metrics()
+        if delete_logs:
+            self.env.cleanup_log_files()
+        if save_metrics_inputs:
+            if delete_logs:
+                msg = (
+                    "Cannot save references to deleted files. Use `delete_logs=False`"
+                    " (default option) to save the metrics inputs."
+                )
+                raise ValueError(msg)
+            self.save_metrics_inputs()
 
     def initialize_metrics(self) -> None:
         """Instantiates the ``metrics`` attribute after the simulation is run."""
         events = self.env.load_events_log_dataframe()
         operations = self.env.load_operations_log_dataframe()
-        power_potential, power_production = self.env.power_production_potential_to_csv(
+        self.env.convert_logs_to_pqt()
+        power_potential, power_production = self.env.power_production_potential_to_pqt(
             windfarm=self.windfarm, operations=operations, return_df=True
         )
         substation_turbine_map = {

--- a/wombat/core/simulation_api.py
+++ b/wombat/core/simulation_api.py
@@ -456,6 +456,13 @@ class Simulation(FromDictMixin):
             Raised when :py:attr:`delete_log_files` :py:attr:`save_metrics_inputs` are
             both set to ``True``.
         """
+        if delete_logs and save_metrics_inputs:
+            msg = (
+                "Cannot save references to deleted files. Use `delete_logs=False`"
+                " (default option) to save the metrics inputs."
+            )
+            raise ValueError(msg)
+
         self.env.run(until=until)
         self.env.convert_logs_to_pqt()
 
@@ -464,12 +471,6 @@ class Simulation(FromDictMixin):
         if delete_logs:
             self.env.cleanup_log_files()
         if save_metrics_inputs:
-            if delete_logs:
-                msg = (
-                    "Cannot save references to deleted files. Use `delete_logs=False`"
-                    " (default option) to save the metrics inputs."
-                )
-                raise ValueError(msg)
             self.save_metrics_inputs()
 
     def initialize_metrics(self) -> None:


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELTE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code higlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Simulation auto log cleanup and efficient data storage

<!-- Describe your contribution here. Please include any code snippets or examples in this section. -->
This PR enables the auto cleanup of log files through the new parameter `delete_log_files` in `Simulation.run()` to reduce the number of steps used for simulation running, results calculation, and cleanup. Crucially, this parameter is incompatible with default `save_metrics_inputs=True`, which must be set to False in order to automatically cleanup the log files. This is done to both preserve the default behavior and to ensure a user can't accidentally delete the log files prematurely.

Additionally, this PR converts all logged data to use the Parquet data format for faster I/O and efficient data storage.

## PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [x] `CHANGELOG.md` has been updated to describe the changes made in this PR
- [x] Documentation
  - [x] Docstrings are up-to-date
  - [x] Related `docs/` files are up-to-date, or added when necessary
  - [x] Documentation has been rebuilt successfully
  - [ ] Examples have been updated
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [x] PR description thoroughly describes the new feature, bug fix, etc.

## Related issues

<!--If one exists, link to a related GitHub Issue.-->
N/A

## Impacted areas of the software

<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why.
-->
- `wombat/core/environment.py`
  - `WombatEnvironment.convert_logs_to_pqt()`: New method to convert the events and operations logs from .csv files to .pqt files immediately after `Simulation.run()` is complete.
  - events, operations, power potential, and power production file names are converted to .pqt extensions.
  - log conversions have an additional step to load the parquet data if the conversion has already been completed.
- `wombat/core/simulation_api.py`
  - `Simulation.run()`: Now has `delete_logs` to safely delete the logging files if `save_metrics_inputs=False`.
 - `wombat/core/post_processor.py`
  - `Metrics._read_data()`: Now runs `pd.read_parquet()` for all inputs.

## Additional supporting information

<!--Fil out at least the versions listed below and those of any packages that may be related.-->
Python version: 3.11
WOMBAT version (`wombat.__version__`): 0.10.4 on develop's latest commit

<!--Add any other context about the problem here.-->


## Test results, if applicable

<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->
Tests pass.