### PR TITLE
Patch: Improve event counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@
   allows the user to automatically delete the logging files that are created after the
   `Metrics` object is initialized.
 - `Metrics.request_summary()` is now available to provide the total number of repair
-  and maintenance requests, number of canceled requests, and the total number of
-  completed requests.
+  and maintenance requests, number of canceled requests, number of incomplete requests,
+  and the number of completed requests.
 
 ### Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## New Features
 
-- `Metrics.dispatch_summary` is now available to provide the number of mobilizations and average
+- `Metrics.dispatch_summary()` is now available to provide the number of mobilizations and average
   charter period across the whole project, or broken down by year and month, as requested.
 - Universalized maintenance starting dates are now able to be set through the primary
   configuration file as `maintenance_start`. This will enable the universalized
@@ -15,6 +15,9 @@
 - `Simulation.run()` has a new parameter called `delete_logs` (defaults to False) that
   allows the user to automatically delete the logging files that are created after the
   `Metrics` object is initialized.
+- `Metrics.request_summary()` is now available to provide the total number of repair
+  and maintenance requests, number of canceled requests, and the total number of
+  completed requests.
 
 ### Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
   run with `pytest` still running the entire test suite.
 - Post-results log files have been converted from a CSV to Parquet file format for
   faster I/O and a smaller memory footprint.
+- Fixes a bug in `Metrics.process_times()` where canceled requests are counted towards
+  the event timing and count.
 
 ## v0.10.4 (12 May 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
   faster I/O and a smaller memory footprint.
 - Fixes a bug in `Metrics.process_times()` where canceled requests are counted towards
   the event timing and count.
+- `Metrics.process_times` has a new flag `include_incompletes` to either summarize all
+  maintenance activity (`False`) or only the completed maintenance activity (`True`).
 
 ## v0.10.4 (12 May 2025)
 

--- a/docs/API/simulation_api.md
+++ b/docs/API/simulation_api.md
@@ -44,8 +44,9 @@ For example usage of the Metrics class and its associated methods, please see th
    :members: from_simulation_outputs, power_production, time_based_availability,
     production_based_availability, capacity_factor, task_completion_rate,
     equipment_costs, service_equipment_utilization, vessel_crew_hours_at_sea,
-    number_of_tows, labor_costs, equipment_labor_cost_breakdowns, emissions,
-    process_times, component_costs, port_fees, project_fixed_costs, opex, npv
+    number_of_tows, dispatch_summary,labor_costs, equipment_labor_cost_breakdowns,
+    emissions, process_times, request_summary, component_costs, port_fees,
+    project_fixed_costs, opex, npv
    :member-order: bysource
    :undoc-members:
    :exclude-members: _yield_comparisons, _repr_compare

--- a/docs/examples/metrics_demonstration.md
+++ b/docs/examples/metrics_demonstration.md
@@ -694,9 +694,9 @@ style(metrics.process_times(include_incompletes=False))
 (metrics-demo:request-sumamry)=
 ## Request Summary
 
-Computes the total number of submitted, canceled, and completed repair and maintenance
-request by subassembly and task description. For further documentation, see the API docs
-here: {py:meth}`wombat.core.post_processor.Metrics.request_summary`.
+Computes the total number of submitted, canceled, incomplete, and completed repair and
+maintenance request by subassembly and task description. For further documentation, see
+the API docs here: {py:meth}`wombat.core.post_processor.Metrics.request_summary`.
 
 **Inputs**:
 

--- a/docs/examples/metrics_demonstration.md
+++ b/docs/examples/metrics_demonstration.md
@@ -79,6 +79,7 @@ is, and how it should be computed.
 - [Fixed Cost Impacts](metrics-demo:fixed-costs): Total fixed costs
 - [OpEx](metrics-demo:opex): Project OpEx
 - [Process Times](metrics-demo:process-times): Timing of various stages of repair and maintenance
+- [Request Summary](metrics-demo:request-summary): Total number of submitted, canceled, and completed repair and maintenance tasks
 - [Power Production](metrics-demo:power-production): Potential and actually produced power
 - [Net Present Value](metrics-demo:npv): Project NPV calculator
 
@@ -672,11 +673,42 @@ performing repairs, and the number of request for each repair category. For furt
 documentation, see the API docs here:
 {py:meth}`wombat.core.post_processor.Metrics.process_times`.
 
+**Inputs**:
+
+- `include_incompletes`
+  - `True`: include requests that have been submitted, but not completed.
+  - `False`: only include requests that have been completed.
+
 **Example Usage**:
 
 ```{code-cell} ipython3
 :tags: ["output_scroll"]
 style(metrics.process_times())
+```
+
+```{code-cell} ipython3
+:tags: ["output_scroll"]
+style(metrics.process_times(include_incompletes=False))
+```
+
+(metrics-demo:request-sumamry)=
+## Request Summary
+
+Computes the total number of submitted, canceled, and completed repair and maintenance
+request by subassembly and task description. For further documentation, see the API docs
+here: {py:meth}`wombat.core.post_processor.Metrics.request_summary`.
+
+**Inputs**:
+
+- `include_incompletes`
+  - `True`: include requests that have been submitted, but not completed.
+  - `False`: only include requests that have been completed.
+
+**Example Usage**:
+
+```{code-cell} ipython3
+:tags: ["output_scroll"]
+style(metrics.request_summary())
 ```
 
 (metrics-demo:power-production)=

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,10 +87,11 @@ def env_setup_full_profile():
     env.cleanup_log_files()
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def setup_ttp():
     """Create a full weather profile environment with proper teardown."""
     sim = Simulation("COREWIND", "morro_bay_tow_to_port.yaml", random_seed=2022)
+    sim.run(8760 * 5)
     yield sim
     sim.env.cleanup_log_files()
 

--- a/tests/regression/test_results.py
+++ b/tests/regression/test_results.py
@@ -89,8 +89,24 @@ def test_event_summary_consistency(setup_ttp):
 
     with check:
         pdt.assert_series_equal(
+            combined.total_requests,
+            combined.canceled_requests
+            + combined.incomplete_requests
+            + combined.completed_requests,
+            check_names=False,
+        )
+
+    with check:
+        pdt.assert_series_equal(
             combined.N,
             (combined.total_requests - combined.canceled_requests),
+            check_names=False,
+        )
+
+    with check:
+        pdt.assert_series_equal(
+            combined.N,
+            (combined.completed_requests + combined.incomplete_requests),
             check_names=False,
         )
 

--- a/tests/regression/test_results.py
+++ b/tests/regression/test_results.py
@@ -7,7 +7,6 @@ from pytest_check import check
 def test_results_consistency(setup_ttp):
     """Multi-facted check to ensure consistency across metrics."""
     sim = setup_ttp
-    sim.run(8760 * 5)
 
     metrics = sim.metrics
     ev = metrics.events
@@ -75,7 +74,9 @@ def test_event_summary_consistency(setup_ttp):
     requests = (
         metrics.request_summary()
         .droplevel("subassembly")
-        .rename(index={"subassembly": "category"})
+        .reset_index()
+        .rename(columns={"task": "category"})
+        .set_index("category")
     )
 
     combined = (

--- a/wombat/core/post_processor.py
+++ b/wombat/core/post_processor.py
@@ -2118,7 +2118,7 @@ class Metrics:
                 columns={
                     "part_name": "subassembly",
                     "reason": "task",
-                    "request_id": "total requests",
+                    "request_id": "total_requests",
                 }
             )
             .groupby(["subassembly", "task"])
@@ -2133,7 +2133,7 @@ class Metrics:
                     columns={
                         "part_name": "subassembly",
                         "reason": "task",
-                        "request_id": "canceled requests",
+                        "request_id": "canceled_requests",
                     }
                 )
                 .groupby(["subassembly", "task"])
@@ -2151,7 +2151,7 @@ class Metrics:
                     columns={
                         "part_name": "subassembly",
                         "reason": "task",
-                        "request_id": "completed requests",
+                        "request_id": "completed_requests",
                     }
                 )
                 .groupby(["subassembly", "task"])

--- a/wombat/core/post_processor.py
+++ b/wombat/core/post_processor.py
@@ -1978,7 +1978,14 @@ class Metrics:
          - downtime: total number of hours where the operations were below 100%.
          - N: total number of processes in the category.
         """
-        events_valid = self.events.loc[self.events.request_id != "na"]
+        canceled_requests = self.events.loc[
+            ~self.events.action.isin(("repair canceled", "maintenance canceled")),
+            "request_id",
+        ]
+        events_valid = self.events.loc[
+            self.events.request_id
+            != "na" & ~self.events.request_id.isin(canceled_requests)
+        ]
 
         # Summarize all the requests data
         request_df = (

--- a/wombat/core/post_processor.py
+++ b/wombat/core/post_processor.py
@@ -2109,6 +2109,10 @@ class Metrics:
             self.events.action.isin(("repair canceled", "maintenance canceled")),
             "request_id",
         ]
+        completed_requests = self.events.loc[
+            self.events.action.isin(("repair complete", "maintenance complete")),
+            "request_id",
+        ]
         total_df = (
             self.events.loc[
                 self.events.action.isin(("repair request", "maintenance request")),
@@ -2142,7 +2146,8 @@ class Metrics:
         )
         completed_df = (
             self.events.loc[
-                self.events.action.isin(("repair complete", "maintenance complete")),
+                self.events.action.isin(("repair request", "maintenance request"))
+                & self.events.request_id.isin(completed_requests),
                 ["part_name", "reason", "request_id"],
             ]
             .rename(

--- a/wombat/core/post_processor.py
+++ b/wombat/core/post_processor.py
@@ -1979,12 +1979,12 @@ class Metrics:
          - N: total number of processes in the category.
         """
         canceled_requests = self.events.loc[
-            ~self.events.action.isin(("repair canceled", "maintenance canceled")),
+            self.events.action.isin(("repair canceled", "maintenance canceled")),
             "request_id",
         ]
         events_valid = self.events.loc[
-            self.events.request_id
-            != "na" & ~self.events.request_id.isin(canceled_requests)
+            self.events.request_id.ne("na")
+            & ~self.events.request_id.isin(canceled_requests)
         ]
 
         # Summarize all the requests data


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELTE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code higlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Improve event counting

<!-- Describe your contribution here. Please include any code snippets or examples in this section. -->
This PR fixes a bug in the `Metrics.process_times()` method that inappropriately counted cancled requests towards the total number of requests, which inflated both the timing and event summaries. To clarify which events are included, a new flag `include_incompletes` is created to ensure unfinsihed events can be in/excluded when necessary for investigating simulation results.

In addition, a new method `Metrics.request_summary()` has been created to count the total number of requests by subassembly and task, the number of canceld events, and the number of completed events, which can be used as an aid to calculating the per even statistics.

New tests have also been included to ensure the number of events is accurately represented in both metrics.

## PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [x] `CHANGELOG.md` has been updated to describe the changes made in this PR
- [x] Documentation
  - [x] Docstrings are up-to-date
  - [x] Related `docs/` files are up-to-date, or added when necessary
  - [x] Documentation has been rebuilt successfully
  - [x] Examples have been updated
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [x] PR description thoroughly describes the new feature, bug fix, etc.

## Related issues

<!--If one exists, link to a related GitHub Issue.-->
N/A

## Impacted areas of the software

<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why.
-->
- `wombat/core/metrics/post_processor.py`
  - `Metrics.process_times`: Exclude canceled events from summary and include the `include_incompletes` parameter to summarize all uncanceled events or just the completed events.
  - `Metrics.request_summary`: New method to summarize the total requests, canceled request, and completed requests by subassembly and task category.
- `tests/conftest.py::setup_ttp`: Now a module-scoped fixture that also runs the simulation.
- `tests/regression/test_results::test_event_summary_consistency`: New method to check that the two event summary metrics produce the same number of total and completed events.

## Additional supporting information

<!--Fil out at least the versions listed below and those of any packages that may be related.-->
Python version: 3.12.9
WOMBAT version (`wombat.__version__`): 0.10.4 on latest develop

<!--Add any other context about the problem here.-->
N/A

## Test results, if applicable

<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->
Tests pass.