### PR TITLE
Bug: Small fixes and spearate COREWIND failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@
   the event timing and count.
 - `Metrics.process_times` has a new flag `include_incompletes` to either summarize all
   maintenance activity (`False`) or only the completed maintenance activity (`True`).
+- Small bug in `Subassembly.interrupt_processes()` is fixed by using a `try`/`except`
+  clause for all interruptions. This allows for the `ServiceEquipment.tow_to_site()` to
+  run without failure after replacing a subassembly. The cause of the failure stems
+  from the inability to interrupt a previously terminated process (caused by triggering
+  a tow-to-port repair).
+- COREWIND turbine failures have been split so that subassemblies only contain a single
+  component grouping to be more compatible with industry modeling assumptions. This
+  ultimately reduces teh resulting number of failures, and therefore costs.
 
 ## v0.10.4 (12 May 2025)
 

--- a/library/corewind/project/config/morro_bay_in_situ_consolidated.yaml
+++ b/library/corewind/project/config/morro_bay_in_situ_consolidated.yaml
@@ -102,8 +102,8 @@ turbines:
     power_curve:
       file: 2020ATB_NREL_Reference_15MW_240.csv
       bin_width: 0.5
-    electrical_system:
-      name: electrical_system
+    power_converter:
+      name: power converter
       maintenance:
       - description: n/a
         time: 0
@@ -119,14 +119,6 @@ turbines:
         operation_reduction: 0.0
         level: 1
         description: power converter minor repair
-      - scale: 2.793
-        shape: 1
-        time: 10
-        materials: 1000
-        service_equipment: CTV
-        operation_reduction: 0.0
-        level: 1
-        description: power electrical system minor repair
       - scale: 2.959
         shape: 1
         time: 28
@@ -135,14 +127,6 @@ turbines:
         operation_reduction: 0.0
         level: 2
         description: power converter major repair
-      - scale: 62.5
-        shape: 1
-        time: 28
-        materials: 5000
-        service_equipment: LCN
-        operation_reduction: 0.0
-        level: 2
-        description: power electrical system major repair
       - scale: 12.99
         shape: 1
         time: 170
@@ -152,6 +136,31 @@ turbines:
         replacement: true
         level: 3
         description: power converter replacement
+    electrical_system:
+      name: electrical system
+      maintenance:
+      - description: n/a
+        time: 0
+        materials: 0
+        service_equipment: CTV
+        frequency: 0
+      failures:
+      - scale: 2.793
+        shape: 1
+        time: 10
+        materials: 1000
+        service_equipment: CTV
+        operation_reduction: 0.0
+        level: 1
+        description: power electrical system minor repair
+      - scale: 62.5
+        shape: 1
+        time: 28
+        materials: 5000
+        service_equipment: LCN
+        operation_reduction: 0.0
+        level: 2
+        description: power electrical system major repair
       - scale: 500
         shape: 1
         time: 54
@@ -161,8 +170,8 @@ turbines:
         replacement: true
         level: 3
         description: power electrical system major replacement
-    hydraulic_system:
-      name: hydraulic_system
+    hydraulic_pitch_system:
+      name: hydraulic pitch system
       maintenance:
       - description: n/a
         time: 0
@@ -178,14 +187,6 @@ turbines:
         operation_reduction: 0
         level: 1
         description: minor pitch system repair
-      - scale: 100
-        shape: 1
-        time: 8
-        materials: 1000
-        service_equipment: CTV
-        operation_reduction: 0
-        level: 1
-        description: minor ballast pump repair
       - scale: 5.587
         shape: 1
         time: 38
@@ -203,6 +204,23 @@ turbines:
         replacement: true
         level: 3
         description: major pitch system replacement
+    ballast_pump:
+      name: ballast pump
+      maintenance:
+      - description: n/a
+        time: 0
+        materials: 0
+        service_equipment: CTV
+        frequency: 0
+      failures:
+      - scale: 100
+        shape: 1
+        time: 8
+        materials: 1000
+        service_equipment: CTV
+        operation_reduction: 0
+        level: 1
+        description: minor ballast pump repair
     yaw_system:
       name: yaw_system
       maintenance:
@@ -319,6 +337,49 @@ turbines:
         service_equipment: DSV
         frequency: 730
       failures:
+      - description: na
+        scale: 0
+        shape: 0
+        time: 0
+        materials: 0
+        service_equipment: CTV
+        level: 0
+        operation_reduction: 0
+    anchor:
+      name: anchor
+      maintenance:
+      - description: na
+        time: 0
+        materials: 0
+        service_equipment: DSV
+        frequency: 0
+      failures:
+      - scale: 66.67
+        shape: 1
+        time: 240
+        materials: 75000
+        service_equipment: AHV
+        operation_reduction: 0
+        level: 1
+        description: major anchor repair
+      - scale: 80
+        shape: 1
+        time: 360
+        materials: 512000
+        service_equipment: AHV
+        operation_reduction: 0
+        replacement: true
+        level: 2
+        description: anchor replacement
+    mooring_lines:
+      name: mooring lines
+      maintenance:
+      - description: na
+        time: 0
+        materials: 0
+        service_equipment: DSV
+        frequency: 0
+      failures:
       - scale: 8.33
         shape: 1
         time: 40
@@ -330,28 +391,11 @@ turbines:
       - scale: 66.67
         shape: 1
         time: 240
-        materials: 75000
-        service_equipment: AHV
-        operation_reduction: 0
-        level: 1
-        description: major anchor repair
-      - scale: 66.67
-        shape: 1
-        time: 240
         materials: 20000
         service_equipment: AHV
         operation_reduction: 0
         level: 2
         description: mooring line major repair
-      - scale: 80
-        shape: 1
-        time: 360
-        materials: 512000
-        service_equipment: AHV
-        operation_reduction: 0
-        replacement: true
-        level: 2
-        description: anchor replacement
       - scale: 80
         shape: 1
         time: 360
@@ -367,7 +411,7 @@ turbines:
         materials: 100000
         service_equipment: CTV
         operation_reduction: 0
-        replacement: true
+        replacement: false
         level: 3
         description: buoyancy module replacement
     drive_train:

--- a/library/corewind/turbines/corewind_15MW.yaml
+++ b/library/corewind/turbines/corewind_15MW.yaml
@@ -3,8 +3,8 @@ capex_kw: 1300
 power_curve:
   file: 2020ATB_NREL_Reference_15MW_240.csv
   bin_width: 0.5
-electrical_system:
-  name: electrical_system
+power_converter:
+  name: power converter
   maintenance:
   - description: n/a
     time: 0
@@ -20,14 +20,6 @@ electrical_system:
     operation_reduction: 0.0
     level: 1
     description: power converter minor repair
-  - scale: 2.793
-    shape: 1
-    time: 10
-    materials: 1000
-    service_equipment: CTV
-    operation_reduction: 0.0
-    level: 1
-    description: power electrical system minor repair
   - scale: 2.959
     shape: 1
     time: 28
@@ -36,14 +28,6 @@ electrical_system:
     operation_reduction: 0.0
     level: 2
     description: power converter major repair
-  - scale: 62.5
-    shape: 1
-    time: 28
-    materials: 5000
-    service_equipment: LCN
-    operation_reduction: 0.0
-    level: 2
-    description: power electrical system major repair
   - scale: 12.99
     shape: 1
     time: 170
@@ -53,6 +37,31 @@ electrical_system:
     replacement: true
     level: 3
     description: power converter replacement
+electrical_system:
+  name: electrical system
+  maintenance:
+  - description: n/a
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    frequency: 0
+  failures:
+  - scale: 2.793
+    shape: 1
+    time: 10
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 1
+    description: power electrical system minor repair
+  - scale: 62.5
+    shape: 1
+    time: 28
+    materials: 5000
+    service_equipment: LCN
+    operation_reduction: 0.0
+    level: 2
+    description: power electrical system major repair
   - scale: 500
     shape: 1
     time: 54
@@ -62,8 +71,8 @@ electrical_system:
     replacement: true
     level: 3
     description: power electrical system major replacement
-hydraulic_system:
-  name: hydraulic_system
+hydraulic_pitch_system:
+  name: hydraulic pitch system
   maintenance:
   - description: n/a
     time: 0
@@ -79,14 +88,6 @@ hydraulic_system:
     operation_reduction: 0
     level: 1
     description: minor pitch system repair
-  - scale: 100
-    shape: 1
-    time: 8
-    materials: 1000
-    service_equipment: CTV
-    operation_reduction: 0
-    level: 1
-    description: minor ballast pump repair
   - scale: 5.587
     shape: 1
     time: 38
@@ -104,6 +105,23 @@ hydraulic_system:
     replacement: true
     level: 3
     description: major pitch system replacement
+ballast_pump:
+  name: ballast pump
+  maintenance:
+  - description: n/a
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    frequency: 0
+  failures:
+  - scale: 100
+    shape: 1
+    time: 8
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: minor ballast pump repair
 yaw_system:
   name: yaw_system
   maintenance:
@@ -220,6 +238,49 @@ supporting_structure:
     service_equipment: DSV
     frequency: 730
   failures:
+  - description: na
+    scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    level: 0
+    operation_reduction: 0
+anchor:
+  name: anchor
+  maintenance:
+  - description: na
+    time: 0
+    materials: 0
+    service_equipment: DSV
+    frequency: 0
+  failures:
+  - scale: 66.67
+    shape: 1
+    time: 240
+    materials: 75000
+    service_equipment: AHV
+    operation_reduction: 0
+    level: 1
+    description: major anchor repair
+  - scale: 80
+    shape: 1
+    time: 360
+    materials: 512000
+    service_equipment: AHV
+    operation_reduction: 0
+    replacement: true
+    level: 2
+    description: anchor replacement
+mooring_lines:
+  name: mooring lines
+  maintenance:
+  - description: na
+    time: 0
+    materials: 0
+    service_equipment: DSV
+    frequency: 0
+  failures:
   - scale: 8.33
     shape: 1
     time: 40
@@ -231,28 +292,11 @@ supporting_structure:
   - scale: 66.67
     shape: 1
     time: 240
-    materials: 75000
-    service_equipment: AHV
-    operation_reduction: 0
-    level: 1
-    description: major anchor repair
-  - scale: 66.67
-    shape: 1
-    time: 240
     materials: 20000
     service_equipment: AHV
     operation_reduction: 0
     level: 2
     description: mooring line major repair
-  - scale: 80
-    shape: 1
-    time: 360
-    materials: 512000
-    service_equipment: AHV
-    operation_reduction: 0
-    replacement: true
-    level: 2
-    description: anchor replacement
   - scale: 80
     shape: 1
     time: 360
@@ -268,7 +312,7 @@ supporting_structure:
     materials: 100000
     service_equipment: CTV
     operation_reduction: 0
-    replacement: true
+    replacement: false
     level: 3
     description: buoyancy module replacement
 drive_train:

--- a/library/corewind/turbines/corewind_15MW_ttp.yaml
+++ b/library/corewind/turbines/corewind_15MW_ttp.yaml
@@ -3,8 +3,8 @@ capex_kw: 1300
 power_curve:
   file: 2020ATB_NREL_Reference_15MW_240.csv
   bin_width: 0.5
-electrical_system:
-  name: electrical_system
+power_converter:
+  name: power converter
   maintenance:
   - description: n/a
     time: 0
@@ -20,14 +20,6 @@ electrical_system:
     operation_reduction: 0.0
     level: 1
     description: power converter minor repair
-  - scale: 2.793
-    shape: 1
-    time: 10
-    materials: 1000
-    service_equipment: CTV
-    operation_reduction: 0.0
-    level: 1
-    description: power electrical system minor repair
   - scale: 2.959
     shape: 1
     time: 28
@@ -36,14 +28,6 @@ electrical_system:
     operation_reduction: 0.0
     level: 2
     description: power converter major repair
-  - scale: 62.5
-    shape: 1
-    time: 28
-    materials: 5000
-    service_equipment: TOW
-    operation_reduction: 0.0
-    level: 2
-    description: power electrical system major repair
   - scale: 12.99
     shape: 1
     time: 170
@@ -53,6 +37,31 @@ electrical_system:
     replacement: true
     level: 3
     description: power converter replacement
+electrical_system:
+  name: electrical system
+  maintenance:
+  - description: n/a
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    frequency: 0
+  failures:
+  - scale: 2.793
+    shape: 1
+    time: 10
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0.0
+    level: 1
+    description: power electrical system minor repair
+  - scale: 62.5
+    shape: 1
+    time: 28
+    materials: 5000
+    service_equipment: TOW
+    operation_reduction: 0.0
+    level: 2
+    description: power electrical system major repair
   - scale: 500
     shape: 1
     time: 54
@@ -62,8 +71,8 @@ electrical_system:
     replacement: true
     level: 3
     description: power electrical system major replacement
-hydraulic_system:
-  name: hydraulic_system
+hydraulic_pitch_system:
+  name: hydraulic pitch system
   maintenance:
   - description: n/a
     time: 0
@@ -79,14 +88,6 @@ hydraulic_system:
     operation_reduction: 0
     level: 1
     description: minor pitch system repair
-  - scale: 100
-    shape: 1
-    time: 8
-    materials: 1000
-    service_equipment: CTV
-    operation_reduction: 0
-    level: 1
-    description: minor ballast pump repair
   - scale: 5.587
     shape: 1
     time: 38
@@ -104,6 +105,23 @@ hydraulic_system:
     replacement: true
     level: 3
     description: major pitch system replacement
+ballast_pump:
+  name: ballast pump
+  maintenance:
+  - description: n/a
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    frequency: 0
+  failures:
+  - scale: 100
+    shape: 1
+    time: 8
+    materials: 1000
+    service_equipment: CTV
+    operation_reduction: 0
+    level: 1
+    description: minor ballast pump repair
 yaw_system:
   name: yaw_system
   maintenance:
@@ -220,6 +238,49 @@ supporting_structure:
     service_equipment: DSV
     frequency: 730
   failures:
+  - description: na
+    scale: 0
+    shape: 0
+    time: 0
+    materials: 0
+    service_equipment: CTV
+    level: 0
+    operation_reduction: 0
+anchor:
+  name: anchor
+  maintenance:
+  - description: na
+    time: 0
+    materials: 0
+    service_equipment: DSV
+    frequency: 0
+  failures:
+  - scale: 66.67
+    shape: 1
+    time: 240
+    materials: 75000
+    service_equipment: AHV
+    operation_reduction: 0
+    level: 1
+    description: major anchor repair
+  - scale: 80
+    shape: 1
+    time: 360
+    materials: 512000
+    service_equipment: AHV
+    operation_reduction: 0
+    replacement: true
+    level: 2
+    description: anchor replacement
+mooring_lines:
+  name: mooring lines
+  maintenance:
+  - description: na
+    time: 0
+    materials: 0
+    service_equipment: DSV
+    frequency: 0
+  failures:
   - scale: 8.33
     shape: 1
     time: 40
@@ -231,28 +292,11 @@ supporting_structure:
   - scale: 66.67
     shape: 1
     time: 240
-    materials: 75000
-    service_equipment: AHV
-    operation_reduction: 0
-    level: 1
-    description: major anchor repair
-  - scale: 66.67
-    shape: 1
-    time: 240
     materials: 20000
     service_equipment: AHV
     operation_reduction: 0
     level: 2
     description: mooring line major repair
-  - scale: 80
-    shape: 1
-    time: 360
-    materials: 512000
-    service_equipment: AHV
-    operation_reduction: 0
-    replacement: true
-    level: 2
-    description: anchor replacement
   - scale: 80
     shape: 1
     time: 360
@@ -268,7 +312,7 @@ supporting_structure:
     materials: 100000
     service_equipment: CTV
     operation_reduction: 0
-    replacement: true
+    replacement: false
     level: 3
     description: buoyancy module replacement
 drive_train:

--- a/wombat/windfarm/system/subassembly.py
+++ b/wombat/windfarm/system/subassembly.py
@@ -123,16 +123,17 @@ class Subassembly:
         cause = "failure"
         if self.id == replacement:
             cause = "replacement"
-        if origin is not None and id(origin) == id(self):
-            for _, process in self.processes.items():
-                try:
-                    process.interrupt(cause=cause)
-                except RuntimeError:  # Process initiating process can't be interrupted
-                    pass
-            return
+        # if origin is not None and id(origin) == id(self):
 
+        # Processes that initiate the process can't be interrupted, nor can replaced
+        # (already cancelled) processes
+        # TODO: better management of the process status is required
         for _, process in self.processes.items():
-            process.interrupt(cause=cause)
+            try:
+                process.interrupt(cause=cause)
+            except RuntimeError:
+                pass
+        return None
 
     def interrupt_all_subassembly_processes(self) -> None:
         """Thin wrapper for ``system.interrupt_all_subassembly_processes``."""

--- a/wombat/windfarm/system/system.py
+++ b/wombat/windfarm/system/system.py
@@ -70,12 +70,12 @@ class System:
         self.servicing_queue.succeed()
         self.cable_failure.succeed()
 
-        system = system.lower().strip()
+        self.system_type = system.lower().strip()
         self._calculate_system_value(subassemblies)
-        if system not in ("turbine", "substation"):
+        if self.system_type not in ("turbine", "substation"):
             raise ValueError("'system' must be one of 'turbine' or 'substation'!")
 
-        self._create_subassemblies(subassemblies, system)
+        self._create_subassemblies(subassemblies)
 
     def _calculate_system_value(self, subassemblies: dict) -> None:
         """Calculates the turbine's value based its capex_kw and capacity.
@@ -89,7 +89,7 @@ class System:
         """
         self.value = subassemblies["capacity_kw"] * subassemblies["capex_kw"]
 
-    def _create_subassemblies(self, subassembly_data: dict, system: str) -> None:
+    def _create_subassemblies(self, subassembly_data: dict) -> None:
         """Creates each subassembly as a separate attribute and also a list for quick
         access.
 
@@ -98,9 +98,6 @@ class System:
         subassembly_data : dict
             Dictionary providing the maintenance and failure definitions for at least
             one subassembly named
-        system : str
-            One of "turbine" or "substation" to indicate if the power curves should also
-            be created, or not.
         """
         # Set the subassembly data variables from the remainder of the keys in the
         # system configuration file/dictionary
@@ -131,7 +128,7 @@ class System:
         )
 
         # If the system is a turbine, create the power curve, if available
-        if system == "turbine":
+        if self.system_type == "turbine":
             self._initialize_power_curve(subassembly_data.get("power_curve", None))
 
     def _initialize_power_curve(self, power_curve_dict: dict | None) -> None:


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELTE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code higlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Small Logic Patches and COREWIND Data Update

<!-- Describe your contribution here. Please include any code snippets or examples in this section. -->
This PR fixes a minor setup and runtime bug, along with providing an update to the COREWIND turbine failure assumptions. In the setup of subassemblies, there is a reference to `System.system_type` which is not yet introduced into the develop branch, so a basic version is included here to ensure develop works. During tow-to-port scenarios, the resetting of processes previously failed for already terminated failure sampling logic (the failure that triggered a tow-to-port repair), so a try/except is used to manage the resetting for any scenario.

This PR also updates the COREWIND data to separate out subassemblies that encompass multiple component's failures into a single represented component group. This is more similar to other models' representation of failure data, and reduces the overall number of failures and total cost.

## PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [x] `CHANGELOG.md` has been updated to describe the changes made in this PR
- [x] Documentation
  - [x] Docstrings are up-to-date
  - [-] Related `docs/` files are up-to-date, or added when necessary
  - [-] Documentation has been rebuilt successfully
  - [-] Examples have been updated
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [x] PR description thoroughly describes the new feature, bug fix, etc.

## Related issues

<!--If one exists, link to a related GitHub Issue.-->
N/A

## Impacted areas of the software

<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why.
-->
- `library/COREWIND/`
  - `turbines/corewind_15mw.yaml`: Splits component grouped under a single subassembly into their own subassembly.
  - `turbines/corewind_15mw_ttp.yaml`: Splits component grouped under a single subassembly into their own subassembly.
  - `project/config/morro_bay_in_situ_consolidated.yaml`: Updated to reflect changes in the in situ turbine configuration file.
- `wombat/windfarm/system/system.py`: Updated to assign a string to the `system_type` which will later be introduced, but had a reference accidentally included in a previous PR.
- `wombat/windfarm/system/subassembly.py::interrupt_processes`: Always runs the `try`/`except RuntimeError` block to interrupt a process to handle both the interrupting process, and a previously terminated process.

## Additional supporting information

<!--Fil out at least the versions listed below and those of any packages that may be related.-->
Python version: 3.12.9
WOMBAT version (`wombat.__version__`): 0.10.4 on latest develop

<!--Add any other context about the problem here.-->
N/A

## Test results, if applicable

<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->
Tests pass