### PR TITLE
Feature: Enable shift ignorable tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,11 @@
   `DataFrame`, in addition to the existing file name string.
 - Adds `examples/electrolyzer_example.ipynb` to demonstrate how to run a standalone
   electrolyzer simulation without creating any intermediary files.
+- Mooring disconnections and reconnections do not consider the tugboat's shift set shift
+  timing considering this process can take multiple days.
+- All parameters starting from the first boolean parameter now must be passed as a
+  keyword argument with the name included (as `x=False` or `x=True, other="value"`), for
+  all methods, except for those in `Metrics` to maintain user workflow compatibility.
 
 ## v0.10.4 (12 May 2025)
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -130,6 +130,9 @@ modeling assumptions as well as the basic operations of the maintenance and fail
     cost for both scheduled and unscheduled servicing equipment. For scheduled equipment,
     the mobilization is scheduled so that the equipment arrives at the site for the
     start of it's first scheduled day.
+  - Mooring disconnections and reconnections operate without considering shift timing
+    to ensure that these (typically) very long processes can find an optimal weather
+    window within the simulation. These typically only occur with tugboats.
   - A wide range of generalized capabilities can be specified for various modeling
     scenarios. It's important to note that outside of the "TOW" designation, there are
     no specific implementations of functionality.

--- a/wombat/core/environment.py
+++ b/wombat/core/environment.py
@@ -889,6 +889,7 @@ class WombatEnvironment(simpy.Environment):
         self,
         windfarm: wombat.windfarm.Windfarm,
         operations: pd.DataFrame | None = None,
+        *,
         return_df: bool = True,
     ) -> tuple[pd.DataFrame, pd.DataFrame]:
         """Creates the power production ``DataFrame`` and optionally returns it.

--- a/wombat/core/library.py
+++ b/wombat/core/library.py
@@ -90,7 +90,7 @@ def load_yaml(path: str | Path, fname: str | Path) -> Any:
 
 
 def create_library_structure(
-    library_path: str | Path, create_init: bool = False
+    library_path: str | Path, *, create_init: bool = False
 ) -> None:
     """Creates the following library structure at ``library_path``. If ``library_path``
     does not exist, then the method will fail.
@@ -154,6 +154,7 @@ def convert_failure_data(
     configuration: str | Path | dict,
     which: str,
     save_name: str | Path | None = None,
+    *,
     return_dict: bool = False,
 ) -> None | dict:
     """Converts the pre-v0.10 failure configuration data for cable, turbine, substation

--- a/wombat/core/port.py
+++ b/wombat/core/port.py
@@ -482,7 +482,7 @@ class Port(RepairsMixin, FilterStore):
         yield self.service_equipment_manager.put(tugboat)
 
     def run_unscheduled_in_situ(
-        self, request: RepairRequest, initial: bool = False
+        self, request: RepairRequest, *, initial: bool = False
     ) -> Generator[Process]:
         """Runs the in-situ repair processes for port-based servicing equipment such as
         tugboats that will always return back to port, but are not necessarily a feature

--- a/wombat/core/repair_management.py
+++ b/wombat/core/repair_management.py
@@ -578,7 +578,7 @@ class RepairManager(FilterStore):
         yield self.in_process_requests.get(lambda x: x is repair)
 
     def enable_requests_for_system(
-        self, system: System | Cable, tow: bool = False
+        self, system: System | Cable, *, tow: bool = False
     ) -> None:
         """Reenables service equipment operations on the provided system.
 

--- a/wombat/core/repair_management.py
+++ b/wombat/core/repair_management.py
@@ -502,7 +502,7 @@ class RepairManager(FilterStore):
         return None
 
     def invalidate_system(
-        self, system: System | Cable | str, tow: bool = False
+        self, system: System | Cable | str, *, tow: bool = False
     ) -> None:
         """Disables the ability for servicing equipment to service a specific system,
         sets the turbine status to be in servicing, and interrupts all the processes

--- a/wombat/core/simulation_api.py
+++ b/wombat/core/simulation_api.py
@@ -432,6 +432,7 @@ class Simulation(FromDictMixin):
     def run(
         self,
         until: int | float | Event | None = None,
+        *,
         create_metrics: bool = True,
         save_metrics_inputs: bool = True,
         delete_logs: bool = False,

--- a/wombat/utilities/plot.py
+++ b/wombat/utilities/plot.py
@@ -14,6 +14,7 @@ def plot_farm_layout(
     windfarm: Windfarm,
     figure_kwargs: dict | None = None,
     plot_kwargs: dict | None = None,
+    *,
     return_fig: bool = False,
 ) -> None | tuple[plt.figure, plt.axes]:
     """Plot the graph representation of the windfarm as represented through WOMBAT.
@@ -72,6 +73,7 @@ def plot_farm_layout(
 def plot_farm_availability(
     sim: Simulation,
     which: str = "energy",
+    *,
     individual_turbines: bool = False,
     farm_95_CI: bool = False,
     figure_kwargs: dict | None = None,
@@ -230,6 +232,7 @@ def plot_operational_levels(
     sim: Simulation,
     figure_kwargs: dict | None = None,
     cbar_label_fontsize: int = 14,
+    *,
     return_fig: bool = False,
 ):
     """Plots an hourly view of the operational levels of the wind farm and individual

--- a/wombat/utilities/time.py
+++ b/wombat/utilities/time.py
@@ -118,7 +118,7 @@ def check_working_hours(
 
 
 def calculate_cost(
-    duration: int | float, rate: float, n_rate: int = 1, daily_rate: bool = False
+    duration: int | float, rate: float, n_rate: int = 1, *, daily_rate: bool = False
 ) -> float:
     """Calculates the equipment cost, or labor cost for either salaried or hourly
     employees.

--- a/wombat/windfarm/windfarm.py
+++ b/wombat/windfarm/windfarm.py
@@ -426,7 +426,7 @@ class Windfarm:
         for start_node, end_node in self.graph.edges():
             self.cable((start_node, end_node)).finish_setup()
 
-    def _setup_logger(self, initial: bool = True):
+    def _setup_logger(self, *, initial: bool = True):
         self._log_columns = [
             "datetime",
             "env_datetime",


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELTE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code higlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Feature: Enable shift ignorable tasks, enforce tugboat mooring connection processes occur w/o respect to shifts, and enforce boolean parameter name usage

<!-- Describe your contribution here. Please include any code snippets or examples in this section. -->
This focuses on ensuring tugboats do not operate w.r.t. shift timing while disconnecting and reconnecting mooring lines for towing operations. To supplement this, the calculation of weather windows can now be calculated with or without the consideration of shift timing.

Further, all boolean inputs and arguments occurring after the first boolean are now forced to be called using the parameter's name as a strict keyword argument. Many methods and functions already enforced this, but many did not, so it is now an expected standard. The only exception (for now) is to allow any metrics calculations to continue passing booleans as a standard argument.

## PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [x] `CHANGELOG.md` has been updated to describe the changes made in this PR
- [x] Documentation
  - [x] Docstrings are up-to-date
  - [x] Related `docs/` files are up-to-date, or added when necessary
  - [x] Documentation has been rebuilt successfully
  - [-] Examples have been updated
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [x] PR description thoroughly describes the new feature, bug fix, etc.

