### PR TITLE
Patch: Fixed date maintenance timing and runaway processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v0.11.2 - TBD
+
+- Fixes a bug in the `Metrics.process_times()` calculation inflating the count of total events
+  when cables are shut down. This is due to immediate logging of the upstream system and cables
+  shutting down with shared logging data.
+
 ## v0.11.1 - 3 July 2025
 
 - Fixes a bug causing 25+ hour mooring connection operations to never complete due to shift delays

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## v0.11.2 - TBD
 
+- Fixes a bug primarily impacting tow-to-port scenarios where individual maintenance and failure
+  models are not being reset upon either replacement or following a tow-to-port repair under
+  certain conditions. This allows for these additional processes to be perpetuated throughout the lifecycle
+  of the simulation while succumbing to the same inital flaw, compounding the number of erroneously
+  additional events. The issue is resolved by the following:
+    1. Multiple subassemblies can now be passed to a `Cable` or `System` object during an
+       interruption, allowing for simpler logic handling.
+    2. TTP repairs no longer reset the subassemblies at the time of towing to port, and instead reset
+       the subassemblies after the turbine has been towed to site. Resetting in the final stage
+       ensures that any newly created processes, and especially fixed date maintenance schedules can
+       not create extra processes between tow, repair, and site return operations.
 - Fixes a bug in the `Metrics.process_times()` calculation inflating the count of total events
   when cables are shut down. This is due to immediate logging of the upstream system and cables
   shutting down with shared logging data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Fixes a bug in the `Metrics.process_times()` calculation inflating the count of total events
   when cables are shut down. This is due to immediate logging of the upstream system and cables
   shutting down with shared logging data.
+- Applies the same fix to the `Metrics.request_summary()` calculation, ensuring duplicated logging
+  messages are not caught up in the end result.
 
 ## v0.11.1 - 3 July 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## v0.11.2 - TBD
+## v0.11.2 - 9 July 2025
 
 - Fixes a bug primarily impacting tow-to-port scenarios where individual maintenance and failure
   models are not being reset upon either replacement or following a tow-to-port repair under

--- a/tests/unit/test_data_classes.py
+++ b/tests/unit/test_data_classes.py
@@ -619,9 +619,11 @@ def test_SubassemblyData():
     N_failure = len(failure_levels)
 
     subassembly = SubassemblyData.from_dict(GENERATOR_SUBASSEMBLY)
-    maintenance_list = [
-        Maintenance.from_dict(m) for m in GENERATOR_SUBASSEMBLY["maintenance"]
-    ]
+
+    # ensure subassembly level default start date gets passed through
+    start = {"start_date": GENERATOR_SUBASSEMBLY["maintenance_start"]}
+    maintenance_list = [start | m for m in GENERATOR_SUBASSEMBLY["maintenance"]]
+    maintenance_list = [Maintenance.from_dict(m) for m in maintenance_list]
     failure_list = [
         Failure.from_dict({**f, "rng": RNG}) for f in GENERATOR_SUBASSEMBLY["failures"]
     ]

--- a/wombat/__init__.py
+++ b/wombat/__init__.py
@@ -4,4 +4,4 @@ from wombat.core import Metrics, Simulation
 from wombat.core.library import create_library_structure, load_yaml
 
 
-__version__ = "0.11.1"
+__version__ = "0.11.2"

--- a/wombat/core/data_classes.py
+++ b/wombat/core/data_classes.py
@@ -490,10 +490,11 @@ def check_start_stop_dates(
 
 def convert_maintenance_list(value: list[dict], self_) -> list[Maintenance]:
     """Converts a list of ``Maintenance`` configuration dictionaries to a list of
-    ``Maintenance`` objects.
+    ``Maintenance`` objects, setting the ``start_date`` if it doesn't exist yet,
+    and adding the ``self_.system_value``.
     """
     kw = {"system_value": self_.system_value, "start_date": self_.maintenance_start}
-    [el.update(kw) for el in value]
+    value = [kw | el for el in value]
     return [Maintenance.from_dict(el) for el in value]
 
 

--- a/wombat/core/post_processor.py
+++ b/wombat/core/post_processor.py
@@ -2095,6 +2095,7 @@ class Metrics:
                 events_valid.action.isin(("repair request", "maintenance request")),
                 ["request_id", "env_time"],
             ]
+            .drop_duplicates(subset=["request_id"])
             .set_index("request_id")
             .sort_index()
         )

--- a/wombat/core/post_processor.py
+++ b/wombat/core/post_processor.py
@@ -2152,26 +2152,30 @@ class Metrics:
         requests = self.events.loc[
             self.events.action.isin(("repair request", "maintenance request")),
             "request_id",
-        ]
+        ].drop_duplicates()
         canceled_requests = self.events.loc[
             self.events.action.isin(("repair canceled", "maintenance canceled")),
             "request_id",
-        ]
+        ].drop_duplicates()
         completed_requests = self.events.loc[
             self.events.action.isin(("repair complete", "maintenance complete")),
             "request_id",
-        ]
+        ].drop_duplicates()
         incomplete_requests = requests.loc[
             ~requests.isin(canceled_requests) & ~requests.isin(completed_requests)
         ]
-        total_df = self.events.loc[
-            self.events.action.isin(("repair request", "maintenance request")),
-            ["part_name", "reason", "request_id"],
-        ].rename(
-            columns={
-                "part_name": "subassembly",
-                "reason": "task",
-            }
+        total_df = (
+            self.events.loc[
+                self.events.action.isin(("repair request", "maintenance request")),
+                ["part_name", "reason", "request_id"],
+            ]
+            .rename(
+                columns={
+                    "part_name": "subassembly",
+                    "reason": "task",
+                }
+            )
+            .drop_duplicates(subset=["request_id"])
         )
         canceled_df = (
             total_df.loc[total_df.request_id.isin(canceled_requests)]

--- a/wombat/windfarm/system/cable.py
+++ b/wombat/windfarm/system/cable.py
@@ -195,7 +195,7 @@ class Cable:
         """
         self.processes = dict(self._create_processes())
 
-    def interrupt_processes(self, replacement: str | None = None) -> None:
+    def interrupt_processes(self, subassembly_full_reset: list[str]) -> None:
         """Interrupts all of the running processes within the subassembly except for the
         process associated with failure that triggers the catastrophic failure.
 
@@ -203,12 +203,12 @@ class Cable:
         ----------
         subassembly : Subassembly
             The subassembly that should have all processes interrupted.
-        replacement: bool, optional
-            If a subassebly `id` is provided, this indicates the interruption is caused
-            by its replacement event. Defaults to None.
+        subassembly_full_reset: list[str]
+            List of all subassebly `id` that will get a full reset of their simulated
+            failure and maintenance processes by a replacement or tow-to-port event.
         """
         cause = "failure"
-        if self.id == replacement:
+        if self.id in subassembly_full_reset:
             cause = "replacement"
 
         for _, process in self.processes.items():
@@ -219,17 +219,21 @@ class Cable:
                 pass
 
     def interrupt_all_subassembly_processes(
-        self, replacement: str | None = None
+        self, subassembly_full_reset: list[str] | None = None
     ) -> None:
         """Thin wrapper for ``interrupt_processes`` for consistent usage with system.
 
         Parameters
         ----------
-        replacement: bool, optional
-            If a subassebly `id` is provided, this indicates the interruption is caused
-            by its replacement event. Defaults to None.
+        subassembly_full_reset: list[str] | None, optional
+            List of all subassebly `id` that will get a full reset of their simulated
+            failure and maintenance processes by a replacement or tow-to-port event.
+            Defaults to None.
         """
-        self.interrupt_processes(replacement=replacement)
+        subassembly_full_reset = (
+            [] if subassembly_full_reset is None else subassembly_full_reset
+        )
+        self.interrupt_processes(subassembly_full_reset=subassembly_full_reset)
 
     def stop_all_upstream_processes(self, failure: Failure | Maintenance) -> None:
         """Stops all upstream turbines and cables from producing power by creating a

--- a/wombat/windfarm/system/subassembly.py
+++ b/wombat/windfarm/system/subassembly.py
@@ -104,7 +104,9 @@ class Subassembly:
         self.processes = dict(self._create_processes())
 
     def interrupt_processes(
-        self, origin: Subassembly | None = None, replacement: str | None = None
+        self,
+        origin: Subassembly | None = None,
+        subassembly_full_reset: list[str] | None = None,
     ) -> None:
         """Interrupts all of the running processes within the subassembly except for the
         process associated with failure that triggers the catastrophic failure.
@@ -116,14 +118,17 @@ class Subassembly:
             from a subassembly shutdown event. If provided, and it is the same as the
             current subassembly, then a try/except flow is used to ensure the process
             that initiated the shutdown is not interrupting itself.
-        replacement: bool, optional
-            If a subassebly `id` is provided, this indicates the interruption is caused
-            by its replacement event. Defaults to None.
+        subassembly_full_reset: list[str]
+            List of all subassebly `id` that will get a full reset of their simulated
+            failure and maintenance processes by a replacement or tow-to-port event.
+            Defaults to None.
         """
+        subassembly_full_reset = (
+            [] if subassembly_full_reset is None else subassembly_full_reset
+        )
         cause = "failure"
-        if self.id == replacement:
+        if self.id in subassembly_full_reset:
             cause = "replacement"
-        # if origin is not None and id(origin) == id(self):
 
         # Processes that initiate the process can't be interrupted, nor can replaced
         # (already cancelled) processes

--- a/wombat/windfarm/system/system.py
+++ b/wombat/windfarm/system/system.py
@@ -236,7 +236,9 @@ class System:
         self.rated_production, *_ = self.power_curve(np.array([rated_capacity]))
 
     def interrupt_all_subassembly_processes(
-        self, origin: Subassembly | None = None, replacement: str | None = None
+        self,
+        origin: Subassembly | None = None,
+        subassembly_full_reset: list[str] | None = None,
     ) -> None:
         """Interrupts the running processes in all of the system's subassemblies.
 
@@ -245,12 +247,14 @@ class System:
         origin : Subassembly
             The subassembly that triggered the request, if the method call is coming
             from a subassembly shutdown event.
-        replacement: bool, optional
-            If a subassebly `id` is provided, this indicates the interruption is caused
-            by its replacement event. Defaults to None.
+        subassembly_full_reset: list[str] | None
+            List of all subassebly `id` that will get a full reset of their simulated
+            failure and maintenance processes by a replacement or tow-to-port event.
         """
         [
-            subassembly.interrupt_processes(origin=origin, replacement=replacement)  # type: ignore
+            subassembly.interrupt_processes(
+                origin=origin, subassembly_full_reset=subassembly_full_reset
+            )  # type: ignore
             for subassembly in self.subassemblies
         ]
 


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELTE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code higlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Patch: Fixed date maintenance timing and runaway processes

<!-- Describe your contribution here. Please include any code snippets or examples in this section. -->
This patch PR fixes 3 interrelated issues:
1. Ensure date-based maintenance uses the correct inuring priority order of using the individual task's specification, then the environment-wide specification, when provided
2. Ensures that when a subassembly is replaced, it is always has its processes reset. This was particularly an issue with tow-to-port repairs that had date-based maintenance tasks occur while at port, causing compounding numbers of additional processes to be created silently. The runaway processes would duplicate with each tow-to-port repair cycle inflating the number of simulated maintenance tasks, failures, and all dependent results.
3. Removes duplicated request ID counts in the metrics caused cable-based logging duplication for when upstream processes are shut down, and rely on shared logging messages.

Additionally, this includes minor logic cleanups and docstring updates as needed.

## PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [x] `CHANGELOG.md` has been updated to describe the changes made in this PR
- [x] Documentation
  - [x] Docstrings are up-to-date
  - [ ] Related `docs/` files are up-to-date, or added when necessary
  - [x] Documentation has been rebuilt successfully
  - [ ] Examples have been updated
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [x] PR description thoroughly describes the new feature, bug fix, etc.

## Related issues

<!--If one exists, link to a related GitHub Issue.-->
N/A

## Impacted areas of the software

<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why.
-->
- `wombat/windfarm/system/`
  - `system.py`, `subassembly.py`, and `cable.py`: All interruption calls allow passing multiple subassemblies that need resetting to streamline the process recreation logic.
- `wombat/core/servicing_equipment.py`:
 - `reset_system_operations`: `subassembly.id` is used in place of the incorrect `subassembly.name` to ensure no subassemblies are skipped during reset.
 - All methods with changed parameters for the `RepairManager` are updated to match the updated kwarg.
- `wombat/core/repair_management.py`
 - `reset_subassembly_processes`: new method to make it explicit when subassembly resetting is being called.
 - `interrupt_system`: `replacement` changed to `subassembly_full_reset` to make the naming more general and explicit.
- `wombat/core/port.py`: minor control flow update, no logic changed.
- `wombat/core/data_classes.py`
 - `convert_maintenance_list`: Changes the order of the dictionary update process to ensure individually specified maintenance starting dates and system values are used in place of the system and environment variables when provided.

## Additional supporting information

<!--Fil out at least the versions listed below and those of any packages that may be related.-->
Python version: 3.12.9
WOMBAT version (`wombat.__version__`): 0.11.1

<!--Add any other context about the problem here.-->
N/A

## Test results, if applicable

<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->
Tests pass