### PR TITLE
Fix: Polars compatibility with Apple Silicon

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.11", "3.12"]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unreleased
+- Install `polars-lts-cpu` by default when installing on MacOS
+- Add MacOS test runners
+
 ## v0.11.2 - 9 July 2025
 
 - Fixes a bug primarily impacting tow-to-port scenarios where individual maintenance and failure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "scipy>=1.8",
     "pandas>=2",
     "polars>=0.20.4",
+    "polars-lts-cpu; sys_platform == 'darwin'",
     "pyarrow>=10",
     "jupyterlab>=3",
     "simpy>=4.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
     "scipy>=1.8",
     "pandas>=2",
     "polars>=0.20.4",
-    "polars-lts-cpu; sys_platform == 'darwin'",
     "pyarrow>=10",
     "jupyterlab>=3",
     "simpy>=4.0.1",
@@ -29,6 +28,7 @@ dependencies = [
     "types-PyYAML>=6",
     "types-python-dateutil>=2.8",
     "python-dateutil",
+    "polars-lts-cpu; sys_platform == 'darwin'",
 ]
 keywords = [
     "python3",


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELTE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code higlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Install `polars-lts-cpu` when using macOS
This PR installs an extra dependency required to run `polars` on apple silicon chips. It also include testing on MacOS runners.

<!-- Describe your contribution here. Please include any code snippets or examples in this section. -->


## PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [x] `CHANGELOG.md` has been updated to describe the changes made in this PR
- [x] Documentation
  - [x] Docstrings are up-to-date
  - [x] Related `docs/` files are up-to-date, or added when necessary
  - [x] Documentation has been rebuilt successfully
  - [-] Examples have been updated
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [x] PR description thoroughly describes the new feature, bug fix, etc.

## Related issues

<!--If one exists, link to a related GitHub Issue.-->


## Impacted areas of the software

<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why.
-->
- `pyproject.toml`: add `polars-lts-cpu`: as a required dependency for MacOS
- `.github/workflows/ci-tests.yml`: run tests on MacOS

## Additional supporting information
WOMBAT tests were failing in H2I and the problem was tracked to the `polars` as a dependency of WOMBAT

<!--Fil out at least the versions listed below and those of any packages that may be related.-->
Python version: 3.11
WOMBAT version (`wombat.__version__`): 0.11.2

<!--Add any other context about the problem here.-->


## Test results, if applicable

<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->
