### PR TITLE
Fix: Correct mismatched datetime resolution with `pd.date_range`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # CHANGELOG
 
-## v0.13.4 - TBD
-
-- Replaces the use of `pandas.date_range` with `polars.datetime_range` for changed default time
-  resolution of us to ns.
-
 ## v0.13.3. - 8 April 2026
 
 - Enable Pandas v3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # CHANGELOG
 
-## v0.13.4 - TBD
+## v0.13.4 - 14 July 2026
 
-- Replaces the use of `pandas.date_range` with `polars.datetime_range` for changed default time
-  resolution of us to ns.
+- Replaces the use of `pandas.date_range` with `polars.datetime_range` in
+  `tests/unit/test_environment.py` to account for Pandas updated default time resolution of us to ns.
 
 ## v0.13.3. - 8 April 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v0.13.4 - TBD
+
+- Replaces the use of `pandas.date_range` with `polars.datetime_range` for changed default time
+  resolution of us to ns.
+
 ## v0.13.3. - 8 April 2026
 
 - Enable Pandas v3.

--- a/tests/unit/test_environment.py
+++ b/tests/unit/test_environment.py
@@ -6,6 +6,7 @@ import datetime
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import polars as pl
 import pytest
 import numpy.testing as npt
@@ -371,12 +372,11 @@ def test_weather_forecast():
 
     # Test for the next 5 hours, but at the top of the hour
     # Starts with hour 0, and ends with the 5th hour following
-    correct_index = pl.datetime_range(
-        datetime.datetime(2002, 1, 1),
-        datetime.datetime(2002, 1, 1, 4),
-        interval="1h",
-        eager=True,
-    ).alias("datetime")
+    correct_index = pl.from_pandas(
+        pd.date_range(
+            "1/1/2002 00:00:00", "1/1/2002 04:00:00", freq="1h", name="datetime"
+        )
+    )
     correct_hour = np.array([0, 1, 2, 3, 4], dtype=float)
     correct_wind = np.array(
         [11.75561096, 10.41321252, 8.959270788, 9.10014808, 9.945059601]
@@ -395,12 +395,11 @@ def test_weather_forecast():
     # Test for 5 hours at an uneven start time increment
     # Starts at hour 1, and ends with the 5th hour following
     env.run(until=0.1)
-    correct_index = pl.datetime_range(
-        datetime.datetime(2002, 1, 1),
-        datetime.datetime(2002, 1, 1, 5),
-        interval="1h",
-        eager=True,
-    ).alias("datetime")
+    correct_index = pl.from_pandas(
+        pd.date_range(
+            "1/1/2002 00:00:00", "1/1/2002 05:00:00", freq="1h", name="datetime"
+        )
+    )
     correct_hour = np.arange(6, dtype=float)
     correct_wind = np.array(
         [11.75561096, 10.41321252, 8.959270788, 9.10014808, 9.945059601, 11.50807971]
@@ -419,12 +418,11 @@ def test_weather_forecast():
     # Test for 5.5 hours at an uneven start time increment
     # Starts at hour 1, and ends at the 7th hour following
     env.run(until=1.2)
-    correct_index = pl.datetime_range(
-        datetime.datetime(2002, 1, 1, 1),
-        datetime.datetime(2002, 1, 1, 7),
-        interval="1h",
-        eager=True,
-    ).alias("datetime")
+    correct_index = pl.from_pandas(
+        pd.date_range(
+            "1/1/2002 01:00:00", "1/1/2002 07:00:00", freq="1h", name="datetime"
+        )
+    )
     correct_hour = np.arange(1, 8, dtype=float)
     correct_wind = np.array(
         [

--- a/tests/unit/test_environment.py
+++ b/tests/unit/test_environment.py
@@ -6,7 +6,6 @@ import datetime
 from pathlib import Path
 
 import numpy as np
-import pandas as pd
 import polars as pl
 import pytest
 import numpy.testing as npt
@@ -372,11 +371,12 @@ def test_weather_forecast():
 
     # Test for the next 5 hours, but at the top of the hour
     # Starts with hour 0, and ends with the 5th hour following
-    correct_index = pl.from_pandas(
-        pd.date_range(
-            "1/1/2002 00:00:00", "1/1/2002 04:00:00", freq="1h", name="datetime"
-        )
-    )
+    correct_index = pl.datetime_range(
+        datetime.datetime(2002, 1, 1),
+        datetime.datetime(2002, 1, 1, 4),
+        interval="1h",
+        eager=True,
+    ).alias("datetime")
     correct_hour = np.array([0, 1, 2, 3, 4], dtype=float)
     correct_wind = np.array(
         [11.75561096, 10.41321252, 8.959270788, 9.10014808, 9.945059601]
@@ -395,11 +395,12 @@ def test_weather_forecast():
     # Test for 5 hours at an uneven start time increment
     # Starts at hour 1, and ends with the 5th hour following
     env.run(until=0.1)
-    correct_index = pl.from_pandas(
-        pd.date_range(
-            "1/1/2002 00:00:00", "1/1/2002 05:00:00", freq="1h", name="datetime"
-        )
-    )
+    correct_index = pl.datetime_range(
+        datetime.datetime(2002, 1, 1),
+        datetime.datetime(2002, 1, 1, 5),
+        interval="1h",
+        eager=True,
+    ).alias("datetime")
     correct_hour = np.arange(6, dtype=float)
     correct_wind = np.array(
         [11.75561096, 10.41321252, 8.959270788, 9.10014808, 9.945059601, 11.50807971]
@@ -418,11 +419,12 @@ def test_weather_forecast():
     # Test for 5.5 hours at an uneven start time increment
     # Starts at hour 1, and ends at the 7th hour following
     env.run(until=1.2)
-    correct_index = pl.from_pandas(
-        pd.date_range(
-            "1/1/2002 01:00:00", "1/1/2002 07:00:00", freq="1h", name="datetime"
-        )
-    )
+    correct_index = pl.datetime_range(
+        datetime.datetime(2002, 1, 1, 1),
+        datetime.datetime(2002, 1, 1, 7),
+        interval="1h",
+        eager=True,
+    ).alias("datetime")
     correct_hour = np.arange(1, 8, dtype=float)
     correct_wind = np.array(
         [

--- a/wombat/__init__.py
+++ b/wombat/__init__.py
@@ -4,4 +4,4 @@ from wombat.core import Metrics, Simulation
 from wombat.core.library import create_library_structure, load_yaml
 
 
-__version__ = "0.13.3"
+__version__ = "0.13.4"


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELTE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code higlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Replace `pd.date_range` with `pl.datetime_range` while testing

<!-- Describe your contribution here. Please include any code snippets or examples in this section. -->
This PR fixes the test failures in `tests/unit/test_environment.py` caused by a mismatched datetime resolution after a changed default setting from µs to ns.

## PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [x] `CHANGELOG.md` has been updated to describe the changes made in this PR
- [x] Documentation
  - [ ] Docstrings are up-to-date
  - [ ] Related `docs/` files are up-to-date, or added when necessary
  - [ ] Documentation has been rebuilt successfully
  - [ ] Examples have been updated
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [x] PR description thoroughly describes the new feature, bug fix, etc.

## Related issues

<!--If one exists, link to a related GitHub Issue.-->
N/A

## Impacted areas of the software

<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why.
-->
- `tests/unit/test_environment.py`: All instance of `pd.date_range` were changed to `pl.datetime_range`

## Additional supporting information

<!--Fill out at least the versions listed below and those of any packages that may be related.-->
Python version: 3.12.9
WOMBAT version (`wombat.__version__`): 0.13.3

<!--Add any other context about the problem here.-->
N/A

## Test results, if applicable

<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->
